### PR TITLE
Fix: Automatic port assignment not working for containers without a service

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -62,7 +62,9 @@ func findContainerByServiceName(dc client.APIClient, svcType string, svcName str
 		svcNeedle := fmt.Sprintf("traefik.%s.services.%s", svcType, svcName)
 		routerNeedle := fmt.Sprintf("traefik.%s.routers.%s", svcType, routerName)
 		for k := range container.Config.Labels {
-			if strings.Contains(k, svcNeedle) || (routerName != "" && strings.Contains(k, routerNeedle)) {
+			if strings.Contains(k, svcNeedle) {
+				return container, nil
+			} else if routerName != "" && strings.Contains(k, routerNeedle) {
 				return container, nil
 			}
 		}

--- a/docker.go
+++ b/docker.go
@@ -48,7 +48,7 @@ func getClientOpts(endpoint string) ([]client.Opt, error) {
 	return opts, nil
 }
 
-func findContainerByServiceName(dc client.APIClient, svcType string, svcName string) (types.ContainerJSON, error) {
+func findContainerByServiceName(dc client.APIClient, svcType string, svcName string, routerName string) (types.ContainerJSON, error) {
 	list, err := dc.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
 		return types.ContainerJSON{}, errors.Wrap(err, "failed to list containers")
@@ -59,9 +59,10 @@ func findContainerByServiceName(dc client.APIClient, svcType string, svcName str
 			return types.ContainerJSON{}, errors.Wrapf(err, "failed to inspect container %s", c.ID)
 		}
 		// check labels
-		needle := fmt.Sprintf("traefik.%s.services.%s", svcType, svcName)
+		svcNeedle := fmt.Sprintf("traefik.%s.services.%s", svcType, svcName)
+		routerNeedle := fmt.Sprintf("traefik.%s.routers.%s", svcType, routerName)
 		for k := range container.Config.Labels {
-			if strings.Contains(k, needle) {
+			if strings.Contains(k, svcNeedle) || (routerName != "" && strings.Contains(k, routerNeedle)) {
 				return container, nil
 			}
 		}

--- a/store_test.go
+++ b/store_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 const NGINX_CONF_JSON = `{"http":{"routers":{"nginx@docker":{"service":"nginx","rule":"Host('nginx.local')"}},"services":{"nginx@docker":{"loadBalancer":{"servers":[{"url":"http://172.20.0.2:80"}],"passHostHeader":true}}}},"tcp":{},"udp":{},"tls":{"options":{"default":{"clientAuth":{},"alpnProtocols":["h2","http/1.1","acme-tls/1"]}}}}`
+const NGINX_CONF_JSON_DIFFRENT_SERVICE_NAME = `{"http":{"routers":{"nginx@docker":{"service":"nginx-nginx","rule":"Host('nginx.local')"}},"services":{"nginx-nginx@docker":{"loadBalancer":{"servers":[{"url":"http://172.20.0.2:80"}],"passHostHeader":true}}}},"tcp":{},"udp":{},"tls":{"options":{"default":{"clientAuth":{},"alpnProtocols":["h2","http/1.1","acme-tls/1"]}}}}`
 
 func Test_collectKeys(t *testing.T) {
 	cfg := &dynamic.Configuration{}


### PR DESCRIPTION
There is an issue with the new automaic port detection introduced in #2 which this PR aims to fix:
When you have a container `/opt/nginx/docker-compose.yml` like this:
```yml
services:
  nginx:
    ports:
     - 1234:80
    labels:
      traefik.enable: true
      traefik.http.routers.nginx.rule: "Host(`example.com`)"
      traefik.http.routers.nginx.entrypoints: web-secure
```
The current detection of `1234` as the port fails, because it looks for `traefik.http.services.nginx-nginx` (traefik assigns `nginx-nginx` as a service name) in the container labels. So I added a check which finds the router of the service and then searches for `traefik.http.nginx`.

What do you think?