### PR TITLE
Add support for `traefik.docker.network`

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -85,6 +85,16 @@ func isPortSet(container types.ContainerJSON, svcType string, svcName string) bo
 	return false
 }
 
+// Check if the network name is explicitly set via label
+func isNetworkSet(container types.ContainerJSON) bool {
+	for k := range container.Config.Labels {
+		if k == "traefik.docker.network" {
+			return true
+		}
+	}
+	return false
+}
+
 func getPortBinding(container types.ContainerJSON) (string, error) {
 	numBindings := len(container.HostConfig.PortBindings)
 	if numBindings > 1 {


### PR DESCRIPTION
Hi,

I hoping to use traefik-kop in a setup where each container has it's own routable IP address, taken from a specific network the host has been assigned for its containers, and unique from the IP or network the host itself is using.
 
Traefik itself previously had problems identifying the correct IP to use for these containers, however the `traefik.docker.network` label tells traefik which docker network it should examine to find the correct IP address.

This PR attempts to add support for this flag to traefik-kop.

Example of it working....

```
~/traefik-kop$ go run ./bin/traefik-kop --verbose --redis-addr $redis_server:6379 --redis-pass $redis_pass
[...]
time="2022-03-14T21:53:49-07:00" level=debug msg="found network name routable_net for cloudflared"
[...]

// this is a "control" container, running without the `traefik.docker.network` flag, and reports the host's IP:
time="2022-03-14T21:53:49-07:00" level=debug msg="writing traefik/http/services/authelia/loadBalancer/servers/0/url = http://10.10.2.194:9091"

// this is the "test" container, running with the `traefik.docker.network` flag, and correctly reports the container's IP
time="2022-03-14T21:53:49-07:00" level=debug msg="writing traefik/http/services/cloudflared/loadBalancer/servers/0/url = http://10.254.254.253:49312"

[...]
```

I've [dog-scienced](https://knowyourmeme.com/memes/i-have-no-idea-what-im-doing) this PR, as I'm unfamiliar with both the internals of traefik and writing golang. Therefore comments on code, structure, etc, all welcome!

Coops.