### PR TITLE
Fix: Use exact service name match when searching container labels

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -65,10 +65,10 @@ func findContainerByServiceName(dc client.APIClient, svcType string, svcName str
 			return types.ContainerJSON{}, errors.Wrapf(err, "failed to inspect container %s", c.ID)
 		}
 		// check labels
-		svcNeedle := fmt.Sprintf("traefik.%s.services.%s", svcType, svcName)
-		routerNeedle := fmt.Sprintf("traefik.%s.routers.%s", svcType, routerName)
+		svcNeedle := fmt.Sprintf("traefik.%s.services.%s.", svcType, svcName)
+		routerNeedle := fmt.Sprintf("traefik.%s.routers.%s.", svcType, routerName)
 		for k := range container.Config.Labels {
-			if strings.Contains(k, svcNeedle) || (routerName != "" && strings.Contains(k, routerNeedle)) {
+			if strings.HasPrefix(k, svcNeedle) || (routerName != "" && strings.HasPrefix(k, routerNeedle)) {
 				logrus.Debugf("found container '%s' (%s) for service '%s'", container.Name, container.ID, svcName)
 				return container, nil
 			}

--- a/docker_test.go
+++ b/docker_test.go
@@ -124,3 +124,14 @@ func Test_helloWorldNoCert(t *testing.T) {
 
 	// assert.Fail(t, "TODO: check for no cert")
 }
+
+func Test_samePrefix(t *testing.T) {
+	store := doTest(t, "prefix.yml")
+
+	// Two services `hello` and `hello-test`.
+	// The former's name is a prefix of the latter. Ensure the matching does not mix them up.
+	assertServiceIPs(t, store, []svc{
+		{"hello", "http", "http://192.168.100.100:5555"},
+		{"hello-test", "http", "http://192.168.100.100:5566"},
+	})
+}

--- a/fixtures/prefix.yml
+++ b/fixtures/prefix.yml
@@ -1,0 +1,29 @@
+
+services:
+  hello:
+    image: helloworld
+    restart: unless-stopped
+    ports:
+      - 5555:5555
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.hello.rule=Host(`hello.local`)"
+      - "traefik.http.routers.hello.service=hello"
+      - "traefik.http.routers.hello.tls=true"
+      - "traefik.http.routers.hello.tls.certresolver=default"
+      - "traefik.http.services.hello.loadbalancer.server.scheme=http"
+      - "traefik.http.services.hello.loadbalancer.server.port=5555"
+
+  hello-test:
+    image: helloworld
+    restart: unless-stopped
+    ports:
+      - 5566:5566
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.hello-test.rule=Host(`hello-test.local`)"
+      - "traefik.http.routers.hello-test.service=hello-test"
+      - "traefik.http.routers.hello-test.tls=true"
+      - "traefik.http.routers.hello-test.tls.certresolver=default"
+      - "traefik.http.services.hello-test.loadbalancer.server.scheme=http"
+      - "traefik.http.services.hello-test.loadbalancer.server.port=5566"


### PR DESCRIPTION
There is an issue with `findContainerByServiceName` where it incorrectly matches containers with similar names, specifically when one service name is a prefix of the other.

The check that the label contains the string `traefik.<svcType>.services.<svcName>` will match for both the service name `<svcName>` but also services such as `<svcName>-suffix`. If the docker container for the longer service is looked up first, then it will incorrectly retrieve the port binding from that container.

The labels should be in the format `traefik.<svcType>.services.<svcName>.<attribute>` so just add a dot at the end of the needle and use `HasPrefix()` to ensure an exact match. The added test verifies the fix for this issue where `hello` would end up with `"http://192.168.100.100:5566"` instead of `5555`. Unfortunately, since it depends in which order the containers will be iterated over, it doesn't fail (without the fix) all the time.

Here is the output of a non-passing run:
```
[...]
time="2024-07-07T12:13:53+02:00" level=debug msg="found container 'hello-test' (hello-test) for service 'hello'"
time="2024-07-07T12:13:53+02:00" level=debug msg="overriding service port from container host-port: using 5566 (was 5555) for hello@docker" service=hello@docker service-type=http
time="2024-07-07T12:13:53+02:00" level=info msg="publishing http://192.168.100.100:5566" service=hello@docker service-type=http
traefik/http/routers/hello/service: hello
traefik/http/routers/hello/tls/certResolver: default
traefik/http/services/hello-test/loadBalancer/servers/0/url: http://192.168.100.100:5566
traefik/http/services/hello-test/loadBalancer/passHostHeader: true
traefik/http/services/hello/loadBalancer/servers/0/url: http://192.168.100.100:5566
traefik/http/routers/hello-test/service: hello-test
traefik/http/routers/hello-test/rule: Host(`hello-test.local`)
traefik/http/routers/hello-test/tls/certResolver: default
traefik/http/routers/hello/rule: Host(`hello.local`)
traefik/http/services/hello/loadBalancer/passHostHeader: true
    traefik-kop/docker_helpers_test.go:320:
                Error Trace:    traefik-kop/docker_helpers_test.go:320
                                                        traefik-kop/docker_test.go:133
                Error:          Not equal:
                                expected: "http://192.168.100.100:5555"
                                actual  : "http://192.168.100.100:5566"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -http://192.168.100.100:5555
                                +http://192.168.100.100:5566
                Test:           Test_samePrefix
                Messages:       service has wrong IP at key: traefik/http/services/hello/loadBalancer/servers/0/url
--- FAIL: Test_samePrefix (0.01s)
FAIL
FAIL    github.com/jittering/traefik-kop        0.842s
```
