### PR TITLE
Fix: Ensure configuration is pushed to Redis after Redis restart

### DIFF
--- a/docker_helpers_test.go
+++ b/docker_helpers_test.go
@@ -36,6 +36,11 @@ func (s testStore) Ping() error {
 	return nil
 }
 
+// Add a method to push the last configuration if needed
+func (s *testStore) KeepConfAlive() error {
+	return nil
+}
+
 func (s *testStore) Store(conf dynamic.Configuration) error {
 	kv, err := ConfigToKV(conf)
 	if err != nil {

--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -111,6 +111,7 @@ func Start(config Config) {
 		NewPollingProvider(
 			time.Second*time.Duration(config.PollInterval),
 			pollingDockerProvider,
+			store,
 		),
 	})
 


### PR DESCRIPTION
**Description:**
The PR addresses issue #45 where traefik-kop fails to push Docker configurations to Redis after Redis restarts, even though it continues to poll Docker configurations correctly.

**Problem:**
When Redis restarts, traefik-kop detects no changes in the Docker configuration and therefore doesn't push the configuration to Redis. This leaves the central Traefik instance without configuration until something in Docker actually changes from traefik-kop's point of view.

**Solution:**
I implemented a Redis sentinel key mechanism in the RedisStore that:
1. Caches the last successfully pushed configuration
2. Adds a sentinel key to Redis after each successful push
3. Checks for the sentinel key's existence during polling cycles
4. Automatically re-pushes the last (cached) configuration if the sentinel key is missing

This ensures that when Redis restarts, traefik-kop detects the missing sentinel key and pushes the last pushed conf, even if nothing has changed in Docker.

This change is minimally invasive and maintains backward compatibility with existing configurations.

PS: It's still a draft because I haven't built and tested it yet.