### PR TITLE
Fix port detection when publishing to ephemeral ports used

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -122,7 +122,9 @@ func getPortBinding(container types.ContainerJSON) (string, error) {
 		if len(v) > 1 {
 			return "", errors.Errorf("found more than one host-port binding for container '%s' (%s)", container.Name, portBindingString(container.HostConfig.PortBindings))
 		}
-		return v[0].HostPort, nil
+		if v[0].HostPort != "0" {
+			return v[0].HostPort, nil
+		}
 	}
 
 	// check for a randomly set port via --publish-all

--- a/docker_helpers_test.go
+++ b/docker_helpers_test.go
@@ -249,7 +249,15 @@ func createContainersJSON(composeConfig *compose.Config) map[string]types.Contai
 					HostPort: fmt.Sprintf("%d", port.Published),
 				},
 			}
-			containerJSON.NetworkSettings.Ports = containerJSON.HostConfig.PortBindings
+		}
+		containerJSON.NetworkSettings.Ports = containerJSON.HostConfig.PortBindings
+		for portID, mappings := range containerJSON.NetworkSettings.Ports {
+			for i, mapping := range mappings {
+				if mapping.HostPort == "0" {
+					// Emulating random port assignment for testing
+					containerJSON.NetworkSettings.Ports[portID][i].HostPort = "12345"
+				}
+			}
 		}
 		containersJSON[service.Name] = containerJSON
 	}

--- a/docker_test.go
+++ b/docker_test.go
@@ -134,6 +134,14 @@ func Test_helloWorldIgnore(t *testing.T) {
 	})
 }
 
+func Test_helloWorldAutoMapped(t *testing.T) {
+	store := doTest(t, "hello-automapped.yml", nil)
+	assert.Equal(t, "hello", store.kv["traefik/http/routers/hello/service"])
+	assertServiceIPs(t, store, []svc{
+		{"hello", "http", "http://192.168.100.100:12345"},
+	})
+}
+
 func Test_samePrefix(t *testing.T) {
 	store := doTest(t, "prefix.yml", nil)
 

--- a/fixtures/hello-automapped.yml
+++ b/fixtures/hello-automapped.yml
@@ -1,0 +1,13 @@
+
+services:
+  hello:
+    image: helloworld
+    restart: unless-stopped
+    ports:
+      - 5555
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.hello.rule=Host(`hello.local`)"
+      - "traefik.http.routers.hello.service=hello"
+      - "traefik.http.routers.hello.tls=true"
+      - "traefik.http.routers.hello.tls.certresolver=default"


### PR DESCRIPTION
This PR fixes [another case](https://github.com/jittering/traefik-kop/issues/6) of random port mapping:
```
ports:
  - 5555
```

Docs on this: [Publishing to ephemeral ports](https://docs.docker.com/get-started/docker-concepts/running-containers/publishing-ports/#publishing-to-ephemeral-ports)

In Docker data it looks like this:
```
"HostConfig": {
    ...
    "PortBindings": {
        "5555/tcp": [
            {
                "HostIp": "0.0.0.0",
                "HostPort": "0"
            }
        ]
    }
    ...
},
"NetworkSettings": {
    ...
    "Ports": {
        "5555/tcp": [
            {
                "HostIp": "0.0.0.0",
                "HostPort": "62510" // randomly assigned port
            }
        ]
    },
    ...
}
```