### PR TITLE
fix: allow outbound IP detection to fail (resolves #51)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .vscode/
-/traefik-kop
+/traefik-kop*
 /dist
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
 ENTRYPOINT ["/traefik-kop"]
-COPY traefik-kop /
+COPY traefik-kop-linux /traefik-kop

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-docker: build-linux
 	docker build --platform linux/amd64 -t ${PROJECT}:latest .
 
 build-linux:
-	GOOS=linux go build ./bin/traefik-kop
+	GOOS=linux go build -o traefik-kop-linux ./bin/traefik-kop
 
 build:
 	go build ./bin/traefik-kop

--- a/bin/traefik-kop/main.go
+++ b/bin/traefik-kop/main.go
@@ -149,6 +149,10 @@ func doStart(c *cli.Context) error {
 		Namespace:    c.String("namespace"),
 	}
 
+	if config.BindIP == "" {
+		log.Fatal("Bind IP cannot be empty")
+	}
+
 	setupLogging(c.Bool("verbose"))
 	logrus.Debugf("using traefik-kop config: %s", fmt.Sprintf("%+v", config))
 
@@ -166,6 +170,9 @@ func getHostname() string {
 
 func getDefaultIP() string {
 	ip := GetOutboundIP()
+	if ip == nil {
+		return ""
+	}
 	return ip.String()
 }
 
@@ -174,7 +181,8 @@ func getDefaultIP() string {
 func GetOutboundIP() net.IP {
 	conn, err := net.Dial("udp", "8.8.8.8:80")
 	if err != nil {
-		log.Fatal(err)
+		log.Warnf("failed to detect outbound IP: %s", err)
+		return nil
 	}
 	defer conn.Close()
 

--- a/testing/internal/Makefile
+++ b/testing/internal/Makefile
@@ -1,0 +1,7 @@
+
+up:
+	cd ../.. && make build-linux
+	docker compose up --build -d
+
+down:
+	docker compose down --remove-orphans

--- a/testing/internal/docker-compose.yml
+++ b/testing/internal/docker-compose.yml
@@ -1,0 +1,32 @@
+# Test case for issue #51
+# https://github.com/jittering/traefik-kop/issues/51
+#
+# kop fails to start if outbound IP cannot be detected. uncomment BIND_IP to resolve.
+services:
+  kop:
+    build: "../../"
+    restart: unless-stopped
+    environment:
+      - "DEBUG=1"
+      - "REDIS_ADDR=redis:6379"
+      # - "BIND_IP=192.168.1.17"
+    depends_on:
+      - redis
+    networks:
+      - kop_test
+      - default
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+  redis:
+    image: redis:7-alpine
+    networks:
+      - kop_test
+      - default
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+
+networks:
+  default:
+    internal: true
+  kop_test:
+    internal: true


### PR DESCRIPTION
kop was not starting if the outbound IP could not be detected (e.g., when only internal networks are used) but the Bind IP was passed some other way (i.e., via ENV). Delay exit until we check those other flags.