### PR TITLE
Fix premature return during load balancer merge

### DIFF
--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -530,12 +530,12 @@ func mergeGenericLoadBalancers(
 		container, err := dc.findContainerByServiceName(svcType, svcName, getRouterOfService(conf, svcName, svcType))
 		if err != nil {
 			logrus.Debugf("failed to find container for service '%s': %s", svcName, err)
-			return
+			continue
 		}
 
 		merge, _ := strconv.ParseBool(container.Config.Labels["traefik.merge-lbs"])
 		if !merge {
-			return
+			continue
 		}
 
 		// Get existing keys from store


### PR DESCRIPTION
## Summary
- avoid exiting early while merging load balancers

## Testing
- `go test ./...` *(fails: downloading modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688291747618832881b5c46116836999