### PR TITLE
feat: get bind-ip from network interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- Add `--bind-interface` (env: `BIND_INTERFACE`) to select the network interface from which to derive the bind IP when `--bind-ip` is not set. This requires the container to be run with `network_mode: host`.
+
 ## v0.17
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ services:
     environment:
       - "REDIS_ADDR=192.168.1.50:6379"
       - "BIND_IP=192.168.1.75"
+      # Alternatively, derive from an interface (requires network_mode: host)
+      # - "BIND_INTERFACE=eth0"
 ```
 
 Then add the usual labels to your target service:
@@ -80,7 +82,7 @@ services:
       - "traefik.http.services.nginx.loadbalancer.server.port=8088"
 ```
 
-See also [bind-ip](#bind-ip) section below.
+See also the [IP Binding](#ip-binding) section below.
 
 ## Configuration
 
@@ -92,7 +94,8 @@ USAGE:
 
 GLOBAL OPTIONS:
    --hostname value       Hostname to identify this node in redis (default: "server.local") [$KOP_HOSTNAME]
-   --bind-ip value        IP address to bind services to (default: "auto.detected.ip.addr") [$BIND_IP]
+   --bind-ip value        IP address to bind services to [$BIND_IP]
+   --bind-interface value Network interface to derive bind IP (overrides auto-detect) [$BIND_INTERFACE]
    --redis-addr value     Redis address (default: "127.0.0.1:6379") [$REDIS_ADDR]
    --redis-pass value     Redis password (if needed) [$REDIS_PASS]
    --redis-db value       Redis DB number (default: 0) [$REDIS_DB]
@@ -106,7 +109,7 @@ GLOBAL OPTIONS:
    --version, -V          Print the version (default: false)
 ```
 
-Most important are the `bind-ip` and `redis-addr` flags.
+Most important are the `bind-ip`/`bind-interface` and `redis-addr` flags.
 
 ## IP Binding
 
@@ -116,8 +119,8 @@ order of precedence (highest first) and detailed descriptions of each setting.
 1. `kop.<service name>.bind.ip` label
 2. `kop.bind.ip` label
 3. Container networking IP
-4. `--bind-ip` CLI flag
-5. `BIND_IP` env var
+4. `--bind-ip` CLI flag (or `BIND_IP` env var)
+5. `--bind-interface` CLI flag (or `BIND_INTERFACE` env var), requires network_mode: host
 6. Auto-detected host IP
 
 ### bind-ip
@@ -130,6 +133,16 @@ than the usual method of using the internal docker-network IPs (by default
 When using host networking this can be auto-detected, however it is advisable in
 the majority of cases to manually set this to the desired IP address. This can
 be done using the docker image by exporting the `BIND_IP` environment variable.
+
+### bind-interface
+
+If you prefer to bind using the primary IPv4 address of a specific network
+interface, you can specify it via `--bind-interface` or the `BIND_INTERFACE`
+environment variable, for example `--bind-interface eth0`. This is used when
+`--bind-ip` is not provided. If the interface has multiple addresses, the first
+non-loopback IPv4 address is selected.
+
+This option requires that the container be run with  `network_mode: host` so that the interface is visible to the container.
 
 ### traefik-kop service labels
 

--- a/bin/traefik-kop/main.go
+++ b/bin/traefik-kop/main.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-    "fmt"
-    "net"
-    "os"
-    "strings"
+	"fmt"
+	"net"
+	"os"
+	"strings"
 
-    traefikkop "github.com/jittering/traefik-kop"
-    "github.com/sirupsen/logrus"
-    "github.com/traefik/traefik/v2/pkg/log"
-    "github.com/urfave/cli/v2"
+	traefikkop "github.com/jittering/traefik-kop"
+	"github.com/sirupsen/logrus"
+	"github.com/traefik/traefik/v2/pkg/log"
+	"github.com/urfave/cli/v2"
 )
 
 const defaultDockerHost = "unix:///var/run/docker.sock"
@@ -53,28 +53,28 @@ func flags() {
 
 		Action: doStart,
 
-        Flags: []cli.Flag{
-            &cli.StringFlag{
-                Name:    "hostname",
-                Usage:   "Hostname to identify this node in redis",
-                Value:   getHostname(),
-                EnvVars: []string{"KOP_HOSTNAME"},
-            },
-            &cli.StringFlag{
-                Name:    "bind-ip",
-                Usage:   "IP address to bind services to",
-                EnvVars: []string{"BIND_IP"},
-            },
-            &cli.StringFlag{
-                Name:    "bind-interface",
-                Usage:   "Network interface to derive bind IP (overrides auto-detect)",
-                EnvVars: []string{"BIND_INTERFACE"},
-            },
-            &cli.StringFlag{
-                Name:    "redis-addr",
-                Usage:   "Redis address",
-                Value:   "127.0.0.1:6379",
-                EnvVars: []string{"REDIS_ADDR"},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "hostname",
+				Usage:   "Hostname to identify this node in redis",
+				Value:   getHostname(),
+				EnvVars: []string{"KOP_HOSTNAME"},
+			},
+			&cli.StringFlag{
+				Name:    "bind-ip",
+				Usage:   "IP address to bind services to",
+				EnvVars: []string{"BIND_IP"},
+			},
+			&cli.StringFlag{
+				Name:    "bind-interface",
+				Usage:   "Network interface to derive bind IP (overrides auto-detect)",
+				EnvVars: []string{"BIND_INTERFACE"},
+			},
+			&cli.StringFlag{
+				Name:    "redis-addr",
+				Usage:   "Redis address",
+				Value:   "127.0.0.1:6379",
+				EnvVars: []string{"REDIS_ADDR"},
 			},
 			&cli.StringFlag{
 				Name:    "redis-pass",
@@ -160,36 +160,32 @@ func splitStringArr(str string) []string {
 }
 
 func doStart(c *cli.Context) error {
-    traefikkop.Version = version
+	traefikkop.Version = version
 
-    namespaces := splitStringArr(c.String("namespace"))
+	namespaces := splitStringArr(c.String("namespace"))
 
-    // Determine bind IP: precedence -> explicit --bind-ip -> --bind-interface -> auto-detect
-    bindIP := strings.TrimSpace(c.String("bind-ip"))
-    if bindIP == "" {
-        iface := strings.TrimSpace(c.String("bind-interface"))
-        if iface != "" {
-            bindIP = getDefaultIP(iface)
-        } else {
-            bindIP = getDefaultIP("")
-        }
-    }
+	// Determine bind IP: precedence -> explicit --bind-ip -> --bind-interface -> auto-detect
+	bindIP := strings.TrimSpace(c.String("bind-ip"))
+	if bindIP == "" {
+		iface := strings.TrimSpace(c.String("bind-interface"))
+		bindIP = getDefaultIP(iface)
+	}
 
-    config := traefikkop.Config{
-        Hostname:     c.String("hostname"),
-        BindIP:       bindIP,
-        Addr:         c.String("redis-addr"),
-        Pass:         c.String("redis-pass"),
-        DB:           c.Int("redis-db"),
-        DockerHost:   c.String("docker-host"),
-        DockerConfig: c.String("docker-config"),
+	config := traefikkop.Config{
+		Hostname:     c.String("hostname"),
+		BindIP:       bindIP,
+		Addr:         c.String("redis-addr"),
+		Pass:         c.String("redis-pass"),
+		DB:           c.Int("redis-db"),
+		DockerHost:   c.String("docker-host"),
+		DockerConfig: c.String("docker-config"),
 		PollInterval: c.Int64("poll-interval"),
 		Namespace:    namespaces,
 	}
 
-    if config.BindIP == "" {
-        log.Fatal("Bind IP cannot be empty")
-    }
+	if config.BindIP == "" {
+		log.Fatal("Bind IP cannot be empty")
+	}
 
 	setupLogging(c.Bool("verbose"))
 	logrus.Debugf("using traefik-kop config: %s", fmt.Sprintf("%+v", config))
@@ -207,63 +203,63 @@ func getHostname() string {
 }
 
 func getDefaultIP(iface string) string {
-    // If a network interface is specified, attempt to get its primary IPv4 address
-    if strings.TrimSpace(iface) != "" {
-        if ip := GetInterfaceIP(iface); ip != nil {
-            return ip.String()
-        }
-        log.Warnf("failed to get IP for interface '%s'; falling back to auto-detect", iface)
-    }
-    ip := GetOutboundIP()
-    if ip == nil {
-        return ""
-    }
-    return ip.String()
+	// If a network interface is specified, attempt to get its primary IPv4 address
+	if strings.TrimSpace(iface) != "" {
+		if ip := GetInterfaceIP(iface); ip != nil {
+			return ip.String()
+		}
+		log.Warnf("failed to get IP for interface '%s'; falling back to auto-detect", iface)
+	}
+	ip := GetOutboundIP()
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
 }
 
 // Get preferred outbound ip of this machine
 // via https://stackoverflow.com/a/37382208/102920
 func GetOutboundIP() net.IP {
-    conn, err := net.Dial("udp", "8.8.8.8:80")
-    if err != nil {
-        log.Warnf("failed to detect outbound IP: %s", err)
-        return nil
-    }
-    defer conn.Close()
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		log.Warnf("failed to detect outbound IP: %s", err)
+		return nil
+	}
+	defer conn.Close()
 
-    localAddr := conn.LocalAddr().(*net.UDPAddr)
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
 
-    return localAddr.IP
+	return localAddr.IP
 }
 
 // GetInterfaceIP returns the first non-loopback IPv4 address for the named interface
 func GetInterfaceIP(name string) net.IP {
-    iface, err := net.InterfaceByName(name)
-    if err != nil {
-        log.Warnf("unable to find interface '%s': %v", name, err)
-        return nil
-    }
-    addrs, err := iface.Addrs()
-    if err != nil {
-        log.Warnf("unable to list addresses for interface '%s': %v", name, err)
-        return nil
-    }
-    for _, a := range addrs {
-        var ip net.IP
-        switch v := a.(type) {
-        case *net.IPNet:
-            ip = v.IP
-        case *net.IPAddr:
-            ip = v.IP
-        }
-        if ip == nil || ip.IsLoopback() {
-            continue
-        }
-        ip = ip.To4()
-        if ip == nil {
-            continue // skip IPv6 for bind default
-        }
-        return ip
-    }
-    return nil
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		log.Warnf("unable to find interface '%s': %v", name, err)
+		return nil
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		log.Warnf("unable to list addresses for interface '%s': %v", name, err)
+		return nil
+	}
+	for _, a := range addrs {
+		var ip net.IP
+		switch v := a.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip == nil || ip.IsLoopback() {
+			continue
+		}
+		ip = ip.To4()
+		if ip == nil {
+			continue // skip IPv6 for bind default
+		}
+		return ip
+	}
+	return nil
 }


### PR DESCRIPTION
Add `--bind-interface` (env: `BIND_INTERFACE`) to select the network interface from which to derive the bind IP when `--bind-ip` is not set.

This requires the container to be run with `network_mode: host`.

Apologies for the indentation-changes, my go formatter does things sometimes.