### PR TITLE
feat: check for services and routers based on kop.$namespace.traefik.…

### DIFF
--- a/bin/traefik-kop/main.go
+++ b/bin/traefik-kop/main.go
@@ -161,9 +161,11 @@ func doStart(c *cli.Context) error {
 	namespaces := splitStringArr(c.String("namespace"))
 
 	config := traefikkop.Config{
-		Hostname:     c.String("hostname"),
-		BindIP:       c.String("bind-ip"),
-		Addr:         c.String("redis-addr"),
+		Hostname: c.String("hostname"),
+		BindIP:   c.String("bind-ip"),
+		Addr:     c.String("redis-addr"),
+		// TODO: uncomment this when we have a way to set the TTL？
+		// RedisTTL:     c.Int("redis-ttl"),
 		Pass:         c.String("redis-pass"),
 		DB:           c.Int("redis-db"),
 		DockerHost:   c.String("docker-host"),

--- a/fixtures/hello-kop-prefixed.yaml
+++ b/fixtures/hello-kop-prefixed.yaml
@@ -1,0 +1,23 @@
+services:
+  helloworld:
+    image: helloworld
+    ports:
+      - "3001:3001"
+      - "23001:23001"
+    labels:
+      - "traefik.enable=true"
+
+      # ----- Local traefik labels (should be ignored by kop)
+      - "traefik.public=true"
+      - "traefik.docker.network=testing_default"
+      - "traefik.http.routers.hello-external.rule=Host(`public.example.test`) && (Path(`/api/script.js`) || Path(`/api/replay.js`))"
+      - "traefik.http.routers.hello-external.entrypoints=cf"
+      - "traefik.http.services.hello-external.loadbalancer.server.port=3001"
+      - "traefik.http.routers.hello-external.service=hello-external"
+
+      # ----- Remote traefik labels via kop (should be processed)
+      - "kop.ns1.traefik.http.routers.hello-internal.rule=Host(`internal.example.test`) && PathPrefix(`/api`)"
+      - "kop.ns1.traefik.http.services.hello-internal.loadbalancer.server.port=23001"
+      - "kop.ns1.traefik.http.routers.hello-internal.entrypoints=websecure"
+      - "kop.ns1.traefik.http.routers.hello-internal.service=hello-internal"
+

--- a/traefik_kop_test.go
+++ b/traefik_kop_test.go
@@ -44,7 +44,7 @@ func Test_replaceIPs(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "172.20.0.2")
 
-	fc := &dockerCache{client: &fakeDockerClient{}, list: nil, details: make(map[string]types.ContainerJSON)}
+	fc := &dockerCache{client: &fakeDockerClient{}, list: nil, details: make(map[string]types.ContainerJSON), originalLabels: make(map[string]map[string]string)}
 
 	// replace and test check again
 	replaceIPs(fc, cfg, "7.7.7.7")
@@ -91,7 +91,7 @@ func Test_replacePorts(t *testing.T) {
 		portLabel: "8888",
 	})
 
-	fc := &dockerCache{client: dc, list: nil, details: make(map[string]types.ContainerJSON)}
+	fc := &dockerCache{client: dc, list: nil, details: make(map[string]types.ContainerJSON), originalLabels: make(map[string]map[string]string)}
 
 	cfg := &dynamic.Configuration{}
 	err := json.Unmarshal([]byte(NGINX_CONF_JSON), cfg)
@@ -138,7 +138,7 @@ func Test_replacePortsNoService(t *testing.T) {
 	dc := createTestClient(map[string]string{
 		"traefik.http.routers.nginx.entrypoints": "web-secure",
 	})
-	fc := &dockerCache{client: dc, list: nil, details: make(map[string]types.ContainerJSON)}
+	fc := &dockerCache{client: dc, list: nil, details: make(map[string]types.ContainerJSON), originalLabels: make(map[string]map[string]string)}
 
 	cfg := &dynamic.Configuration{}
 	err := json.Unmarshal([]byte(NGINX_CONF_JSON_DIFFRENT_SERVICE_NAME), cfg)


### PR DESCRIPTION
This PR adds support for the `kop.$namespace` label prefix.
The goal is to handle cases where a container has labels for both the **local Traefik** (running on the same host) and a **remote Traefik** (via traefik-kop).

Example:

```yaml
services:
  helloworld:
    # ...
    labels:
      # ----- Local Traefik labels (should be ignored by kop)
      - "traefik.public=true"
      - "traefik.docker.network=testing_default"
      - "traefik.http.routers.hello-external.rule=Host(`public.example.test`) && (Path(`/api/script.js`) || Path(`/api/replay.js`))"
      - "traefik.http.routers.hello-external.entrypoints=cf"
      - "traefik.http.services.hello-external.loadbalancer.server.port=3001"
      - "traefik.http.routers.hello-external.service=hello-external"

      # ----- Remote Traefik labels via kop (should be processed)
      - "kop.ns1.traefik.http.routers.hello-internal.rule=Host(`internal.example.test`) && PathPrefix(`/api`)"
      - "kop.ns1.traefik.http.services.hello-internal.loadbalancer.server.port=23001"
      - "kop.ns1.traefik.http.routers.hello-internal.entrypoints=websecure"
      - "kop.ns1.traefik.http.routers.hello-internal.service=hello-internal"
```

**PS:** When `kop.$namespace.traefik.*` labels are present, there is no longer a need for the legacy `kop.namespace=$namespace` label. For backward compatibility, if `kop.namespace` is still provided, kop will continue to forward **all** `traefik.*` labels as before.

---

### Notes

* I’ve implemented and tested this feature (with a lot of help from AI).
* I tried to keep it backward-compatible and avoid breaking existing setups.
* The original label detection relied on the Traefik Docker provider (Not sure!), which only considers labels starting with `traefik.*`. This often leads to conflicts with the local Traefik instance.
* I think the `kop.$namespace` prefix is a cleaner approach, although it required significant changes (parsing raw Docker labels instead of only relying on the provider).

If there are any issues with this implementation, or if there is a better approach, I’d be happy to adjust.

