### PR TITLE
feat: allow filtering traefik labels using prefix (resolves #67)

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -65,8 +65,17 @@ jobs:
         run: |
           set -eo pipefail
           goreleaser release --clean --snapshot --parallelism 2
-          # Manually push docker images to :latest tag
+          # Manually push docker images
           docker images --format '{{ .Repository }}:{{ .Tag }}' \
             | grep kop \
             | grep -v none \
             | xargs -n 1 docker push
+
+      - name: Cleanup local docker iamges
+        run: |
+          set -eo pipefail
+          docker images \
+            | grep ghcr.io/jittering/traefik-kop \
+            | awk '{print $3}' \
+            | sort | uniq \
+            | xargs docker rmi -f

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,8 +1,9 @@
 name: on-push
 
 on:
-  create: {}
-  push: {}
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ logic. It reads the container labels from the local docker node and publishes
 them to a given `redis` instance. Simply configure your `traefik` node with a
 `redis` provider and point it to the same instance, as in the diagram above.
 
+## Contents
+
+- [traefik-kop](#traefik-kop)
+  - [Contents](#contents)
+  - [Usage](#usage)
+  - [Configuration](#configuration)
+  - [IP Binding](#ip-binding)
+    - [bind-ip](#bind-ip)
+    - [bind-interface](#bind-interface)
+    - [traefik-kop service labels](#traefik-kop-service-labels)
+    - [Load Balancer Merging](#load-balancer-merging)
+    - [Container Networking](#container-networking)
+  - [Service port binding](#service-port-binding)
+  - [Namespaces](#namespaces)
+    - [Namespace via label prefix](#namespace-via-label-prefix)
+  - [Docker API](#docker-api)
+    - [Traefik Docker Provider Config](#traefik-docker-provider-config)
+  - [Releasing](#releasing)
+  - [License](#license)
+
+
 ## Usage
 
 Configure `traefik` to use the redis provider, for example via `traefik.yml`:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ GLOBAL OPTIONS:
    --redis-ttl value      Redis TTL (in seconds) (default: 0) [$REDIS_TTL]
    --docker-host value    Docker endpoint (default: "unix:///var/run/docker.sock") [$DOCKER_HOST]
    --docker-config value  Docker provider config (file must end in .yaml) [$DOCKER_CONFIG]
+   --docker-prefix value  Docker label prefix [$DOCKER_PREFIX]
    --poll-interval value  Poll interval for refreshing container list (default: 60) [$KOP_POLL_INTERVAL]
    --namespace value      Namespace to process containers for [$NAMESPACE]
    --verbose              Enable debug logging (default: false) [$VERBOSE, $DEBUG]
@@ -265,6 +266,43 @@ services:
     labels:
       # will be exposed because it has namespace 'staging'
       - "kop.namespace=staging,experimental"
+```
+
+### Namespace via label prefix
+
+An alternative method of namespacing is to add a custom prefix for your traefik-related labels. This
+works as an *inclusion* filter for `traefik-kop` and an *exclusion* filter for `traefik`. This can
+be useful in a scenario here you are running both `traefik` and `traefik-kop` side-by-side on the
+same host.
+
+```yaml
+services:
+  nginx:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers..."
+      - "traefik..."
+```
+
+becomes
+
+```yaml
+services:
+  traefik-kop:
+    image: "ghcr.io/jittering/traefik-kop:latest"
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - "REDIS_ADDR=192.168.1.50:6379"
+      - "BIND_IP=192.168.1.75"
+      - "DOCKER_PREFIX=kop.public"
+
+  nginx:
+    labels:
+      - "kop.public.traefik.enable=true"
+      - "kop.public.traefik.http.routers..."
+      - "kop.public.traefik..."
 ```
 
 

--- a/bin/traefik-kop/main.go
+++ b/bin/traefik-kop/main.go
@@ -110,6 +110,11 @@ func flags() {
 				Usage:   "Docker provider config (file must end in .yaml)",
 				EnvVars: []string{"DOCKER_CONFIG"},
 			},
+			&cli.StringFlag{
+				Name:    "docker-prefix",
+				Usage:   "Docker label prefix",
+				EnvVars: []string{"DOCKER_PREFIX"},
+			},
 			&cli.Int64Flag{
 				Name:    "poll-interval",
 				Usage:   "Poll interval for refreshing container list",
@@ -187,6 +192,7 @@ func doStart(c *cli.Context) error {
 		RedisTTL:     c.Int("redis-ttl"),
 		DockerHost:   c.String("docker-host"),
 		DockerConfig: c.String("docker-config"),
+		DockerPrefix: c.String("docker-prefix"),
 		PollInterval: c.Int64("poll-interval"),
 		Namespace:    namespaces,
 	}

--- a/config.go
+++ b/config.go
@@ -15,6 +15,9 @@ import (
 type Config struct {
 	DockerConfig string
 	DockerHost   string
+
+	// prefix for traefik labels to accept
+	DockerPrefix string
 	Hostname     string
 	BindIP       string
 	RedisAddr    string

--- a/docker_proxy.go
+++ b/docker_proxy.go
@@ -122,6 +122,9 @@ func (s *DockerProxyServer) handleEvents(c *fiber.Ctx) error {
 		encoder := json.NewEncoder(w)
 		for {
 			select {
+			case <-c.Context().Done():
+				return
+
 			case event := <-eventsCh:
 				if event.Type == "container" && event.Actor.Attributes != nil {
 					event.Actor.Attributes = s.filterLabels(event.Actor.Attributes)
@@ -137,6 +140,7 @@ func (s *DockerProxyServer) handleEvents(c *fiber.Ctx) error {
 					if e != nil {
 						logrus.Errorf("Error encoding error: %v", e)
 					}
+					return
 				}
 			}
 			err := w.Flush()

--- a/docker_proxy.go
+++ b/docker_proxy.go
@@ -1,0 +1,173 @@
+package traefikkop
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/logger"
+	"github.com/sirupsen/logrus"
+	"github.com/valyala/fasthttp"
+)
+
+func getAvailablePort() (net.Listener, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// DockerProxyServer is a proxy server that filters docker labels based on a prefix
+type DockerProxyServer struct {
+	upstream    client.APIClient
+	labelPrefix string
+}
+
+func createProxy(upstream client.APIClient, labelPrefix string) *DockerProxyServer {
+	if labelPrefix != "" && !strings.HasSuffix(labelPrefix, ".") {
+		labelPrefix += "."
+	}
+	return &DockerProxyServer{
+		upstream:    upstream,
+		labelPrefix: labelPrefix,
+	}
+}
+
+func (s *DockerProxyServer) filterLabels(labels map[string]string) map[string]string {
+	if s.labelPrefix == "" || labels == nil {
+		return labels
+	}
+
+	newLabels := make(map[string]string)
+
+	for k, v := range labels {
+		if strings.HasPrefix(k, s.labelPrefix) {
+			// strip prefix from our labels
+			newKey := strings.TrimPrefix(k, s.labelPrefix)
+			newLabels[newKey] = v
+		} else if !strings.HasPrefix(k, "traefik.") {
+			// keep every other than traefik.* labels as is
+			newLabels[k] = v
+		}
+	}
+
+	return newLabels
+}
+
+func (s *DockerProxyServer) start() (*fiber.App, string) {
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	if os.Getenv("DEBUG") != "" {
+		app.Use(logger.New())
+	}
+
+	app.Get("/v*/version", func(c *fiber.Ctx) error {
+		v, err := s.upstream.ServerVersion(context.Background())
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		}
+		return c.JSON(v)
+	})
+
+	app.Get("/v*/containers/json", func(c *fiber.Ctx) error {
+		containers, err := s.upstream.ContainerList(context.Background(), container.ListOptions{})
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		}
+
+		// modify labels
+		for _, container := range containers {
+			container.Labels = s.filterLabels(container.Labels)
+		}
+
+		return c.JSON(containers)
+	})
+
+	app.Get("/v*/containers/:id/json", func(c *fiber.Ctx) error {
+		container, err := s.upstream.ContainerInspect(context.Background(), c.Params("id"))
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		}
+
+		if container.Config != nil {
+			container.Config.Labels = s.filterLabels(container.Config.Labels)
+		}
+
+		return c.JSON(container)
+	})
+
+	app.Get("/v*/events", func(c *fiber.Ctx) error {
+		var fa filters.Args
+		f := c.Query("filters")
+		if f != "" {
+			var err error
+			fa, err = filters.FromJSON(f)
+			if err != nil {
+				return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+			}
+		}
+
+		eventsCh, errCh := s.upstream.Events(context.Background(), events.ListOptions{Filters: fa})
+
+		c.Status(fiber.StatusOK).Context().SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
+			encoder := json.NewEncoder(w)
+			for {
+				select {
+				case event := <-eventsCh:
+					if event.Type == "container" && event.Actor.Attributes != nil {
+						event.Actor.Attributes = s.filterLabels(event.Actor.Attributes)
+					}
+
+					err := encoder.Encode(event)
+					if err != nil {
+						logrus.Errorf("Error encoding event: %v", err)
+					}
+				case err := <-errCh:
+					if err != nil {
+						e := encoder.Encode(err)
+						if e != nil {
+							logrus.Errorf("Error encoding error: %v", e)
+						}
+					}
+				}
+				err := w.Flush()
+				if err != nil {
+					break
+				}
+			}
+		}))
+
+		return nil
+	})
+
+	app.Get("/*", func(c *fiber.Ctx) error {
+		logrus.Warnf("Unhandled request: %s %s", c.Method(), c.OriginalURL())
+		return c.Status(fiber.StatusNotFound).SendString("Not Found")
+	})
+
+	listener, err := getAvailablePort()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	go app.Listener(listener)
+
+	dockerEndpoint := fmt.Sprintf("http://localhost:%d", listener.Addr().(*net.TCPAddr).Port)
+
+	return app, dockerEndpoint
+}

--- a/docker_proxy.go
+++ b/docker_proxy.go
@@ -168,7 +168,7 @@ func (s *DockerProxyServer) start() (*fiber.App, string) {
 	app.Get("/v*/containers/json", s.handleContainersList)
 	app.Get("/v*/containers/:id/json", s.handleContainerInspect)
 	app.Get("/v*/events", s.handleEvents)
-	app.Get("/*", s.handleNotFound)
+	app.All("/*", s.handleNotFound)
 
 	listener, err := getAvailablePort()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/docker/docker v27.1.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/gofiber/fiber/v2 v2.52.5
+	github.com/opencontainers/image-spec v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/redis/go-redis/v9 v9.11.0
 	github.com/ryanuber/go-glob v1.0.0
@@ -24,6 +25,7 @@ require (
 	github.com/traefik/paerser v0.2.2
 	github.com/traefik/traefik/v2 v2.11.27
 	github.com/urfave/cli/v2 v2.27.6
+	github.com/valyala/fasthttp v1.54.0
 	golang.org/x/exp v0.0.0-20241210194714-1829a127f884
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -257,7 +259,6 @@ require (
 	github.com/nzdjb/go-metaname v1.0.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.20.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5 // indirect
@@ -322,7 +323,6 @@ require (
 	github.com/unrolled/render v1.0.2 // indirect
 	github.com/unrolled/secure v1.0.9 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.54.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
 	github.com/vinyldns/go-vinyldns v0.9.16 // indirect
 	github.com/volcengine/volc-sdk-golang v1.0.199 // indirect

--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -165,3 +165,17 @@ services:
       # not explicitly set, let kop figure it out
       # - "traefik.http.services.ephemeral.loadbalancer.server.scheme=http"
       # - "traefik.http.services.ephemeral.loadbalancer.server.port=8099"
+
+  nginx_prefix:
+    image: "nginx:alpine"
+    restart: unless-stopped
+    ports:
+      - 8090:80
+    labels:
+      - "kop.baz.traefik.enable=true"
+      - "kop.baz.traefik.http.routers.nginx.rule=Host(`nginx.local`)"
+      - "kop.baz.traefik.http.routers.nginx.tls=true"
+      - "kop.baz.traefik.http.routers.nginx.tls.certresolver=default"
+      - "kop.baz.traefik.http.services.nginx.loadbalancer.server.scheme=http"
+      - "kop.baz.traefik.http.services.nginx.loadbalancer.server.port=8088"
+


### PR DESCRIPTION
@ChanningHe here's the solution I came up with. It builds on the proxy code I wrote for tests but uses it to filter labels between the provider and the upstream docker server. Let me know if this works for you