### PR TITLE
feat: more complete config to KV conversion

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -124,6 +124,12 @@ func Test_helloWorldNoCert(t *testing.T) {
 	})
 }
 
+func Test_routerTLSWithoutCertResolver(t *testing.T) {
+	store := processFile(t, "musicassistant-tls.yml")
+
+	assert.Equal(t, "true", g(store, "traefik/http/routers/musicassistant/tls"))
+}
+
 func g(s TraefikStore, k string) string {
 	v, err := s.Get(k)
 	if err != nil {

--- a/fixtures/musicassistant-tls.yml
+++ b/fixtures/musicassistant-tls.yml
@@ -1,0 +1,11 @@
+services:
+  musicassistant:
+    image: helloworld
+    restart: unless-stopped
+    ports:
+      - 5555:5555
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.musicassistant.rule=Host(`musicassistant.example.com`)"
+      - "traefik.http.routers.musicassistant.entrypoints=websecure"
+      - "traefik.http.routers.musicassistant.tls=true"

--- a/fixtures/prefix-bindip.yml
+++ b/fixtures/prefix-bindip.yml
@@ -21,7 +21,7 @@ services:
     labels:
       - "foo.traefik.enable=true"
       - "foo.traefik.http.routers.unprefixed.rule=Host(`hello-prefix2.local`)"
-      - "foo.traefik.http.routers.unprefixed.service=prefixed"
+      - "foo.traefik.http.routers.unprefixed.service=unprefixed"
       - "foo.traefik.http.routers.unprefixed.tls=true"
       - "foo.traefik.http.routers.unprefixed.tls.certresolver=default"
       - "foo.traefik.http.services.unprefixed.loadbalancer.server.scheme=http"

--- a/kv.go
+++ b/kv.go
@@ -1,6 +1,7 @@
 package traefikkop
 
 import (
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -8,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 	"github.com/traefik/traefik/v3/pkg/config/dynamic"
 )
 
@@ -50,87 +49,292 @@ func (kv *KV) add(val interface{}, format string, a ...interface{}) {
 // ConfigToKV flattens the given configuration into a format suitable for
 // putting into a KV store such as redis
 func ConfigToKV(conf dynamic.Configuration) (map[string]interface{}, error) {
-	b, err := json.Marshal(conf)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create kv")
-	}
-
-	hash := make(map[string]interface{})
-	err = json.Unmarshal(b, &hash)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create kv")
-	}
-
 	kv := NewKV()
-	walk(kv, "traefik", hash, "")
+	_, err := walkTypedValue(kv, "traefik", reflect.TypeOf(conf), reflect.ValueOf(conf), walkOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kv: %w", err)
+	}
 
 	return kv.data, nil
 }
 
-var reKeyName = regexp.MustCompile(`^traefik/(http|tcp|udp)/(router|service|middleware)s$`)
+var (
+	reKeyName         = regexp.MustCompile(`^traefik/(http|tcp|udp)/(router|service|middleware)s$`)
+	jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+)
 
-func walk(kv *KV, path string, obj interface{}, pos string) {
-	if obj == nil {
-		return
+type walkOptions struct {
+	allowEmpty bool
+}
+
+func walkTypedValue(kv *KV, path string, typ reflect.Type, val reflect.Value, opts walkOptions) (bool, error) {
+	if typ == nil || !val.IsValid() {
+		return false, nil
 	}
 
-	val := reflect.ValueOf(obj)
+	for typ.Kind() == reflect.Interface {
+		if val.IsNil() {
+			return false, nil
+		}
+		val = val.Elem()
+		typ = val.Type()
+	}
+
+	if typ.Kind() == reflect.Pointer {
+		if val.IsNil() {
+			return false, nil
+		}
+
+		added, err := walkTypedValue(kv, path, typ.Elem(), val.Elem(), walkOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if !added && opts.allowEmpty && typ.Elem().Kind() == reflect.Struct {
+			kv.add("true", path)
+			return true, nil
+		}
+
+		return added, nil
+	}
+
+	if isLeafType(typ) {
+		s, ok, err := leafString(typ, val)
+		if err != nil {
+			return false, fmt.Errorf("walk %s: %w", path, err)
+		}
+		if ok {
+			kv.add(s, path)
+			return true, nil
+		}
+		return false, nil
+	}
+
+	switch typ.Kind() {
+	case reflect.Struct:
+		return walkStructValue(kv, path, typ, val)
+	case reflect.Map:
+		return walkMapValue(kv, path, typ, val)
+	case reflect.Slice, reflect.Array:
+		return walkSliceValue(kv, path, typ, val)
+	default:
+		return false, nil
+	}
+}
+
+func walkStructValue(kv *KV, path string, typ reflect.Type, val reflect.Value) (bool, error) {
+	addedAny := false
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+
+		fieldName, omitEmpty, skip := jsonFieldName(field)
+		if skip {
+			continue
+		}
+
+		fieldValue := val.Field(i)
+		if omitEmpty && isEmptyJSONValue(fieldValue) {
+			continue
+		}
+
+		if field.Anonymous && fieldName == field.Name {
+			added, err := walkTypedValue(kv, path, field.Type, fieldValue, walkOptions{})
+			if err != nil {
+				return false, err
+			}
+			addedAny = addedAny || added
+			continue
+		}
+
+		childPath := joinPath(path, fieldName)
+		added, err := walkTypedValue(kv, childPath, field.Type, fieldValue, walkOptions{allowEmpty: field.Tag.Get("label") == "allowEmpty"})
+		if err != nil {
+			return false, err
+		}
+		addedAny = addedAny || added
+	}
+
+	return addedAny, nil
+}
+
+func walkMapValue(kv *KV, path string, typ reflect.Type, val reflect.Value) (bool, error) {
+	if val.IsNil() || val.Len() == 0 {
+		return false, nil
+	}
+
+	if typ.Key().Kind() != reflect.String {
+		return false, fmt.Errorf("unsupported map key type %s at %s", typ.Key(), path)
+	}
+
+	addedAny := false
+	iter := val.MapRange()
+	for iter.Next() {
+		key := iter.Key().String()
+		if reKeyName.MatchString(path) {
+			key = stripDocker(key)
+		}
+
+		added, err := walkTypedValue(kv, joinPath(path, key), typ.Elem(), iter.Value(), walkOptions{})
+		if err != nil {
+			return false, err
+		}
+		addedAny = addedAny || added
+	}
+
+	return addedAny, nil
+}
+
+func walkSliceValue(kv *KV, path string, typ reflect.Type, val reflect.Value) (bool, error) {
+	if typ.Kind() == reflect.Slice && val.IsNil() {
+		return false, nil
+	}
+
+	if val.Len() == 0 {
+		return false, nil
+	}
+
+	addedAny := false
+	for i := 0; i < val.Len(); i++ {
+		added, err := walkTypedValue(kv, fmt.Sprintf("%s/%d", path, i), typ.Elem(), val.Index(i), walkOptions{})
+		if err != nil {
+			return false, err
+		}
+		addedAny = addedAny || added
+	}
+
+	return addedAny, nil
+}
+
+func isLeafType(typ reflect.Type) bool {
+	if typ.Implements(textMarshalerType) || reflect.PointerTo(typ).Implements(textMarshalerType) ||
+		typ.Implements(jsonMarshalerType) || reflect.PointerTo(typ).Implements(jsonMarshalerType) {
+		return true
+	}
+	switch typ.Kind() {
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.String:
+		return true
+	default:
+		return false
+	}
+}
+
+func leafString(typ reflect.Type, val reflect.Value) (string, bool, error) {
+	// Custom text marshaler (e.g., ptypes.Duration) — preferred, gives raw text
+	if v, ok := marshalerValue(val, textMarshalerType); ok {
+		b, err := v.(encoding.TextMarshaler).MarshalText()
+		if err != nil {
+			return "", false, err
+		}
+		s := string(b)
+		return s, s != "", nil
+	}
+
+	// json.Marshaler fallback (without TextMarshaler); use JSON roundtrip
+	if v, ok := marshalerValue(val, jsonMarshalerType); ok {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", false, err
+		}
+		var s string
+		if err := json.Unmarshal(b, &s); err == nil {
+			return s, s != "", nil
+		}
+		s = strings.Trim(string(b), `"`)
+		return s, s != "", nil
+	}
+
+	// Primitives
+	switch typ.Kind() {
+	case reflect.String:
+		s := val.String()
+		return s, s != "", nil
+	case reflect.Bool:
+		return strconv.FormatBool(val.Bool()), true, nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(val.Int(), 10), true, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return strconv.FormatUint(val.Uint(), 10), true, nil
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(val.Float(), 'f', -1, 64), true, nil
+	}
+	return "", false, nil
+}
+
+// marshalerValue returns val (or pointer-to-val) as an interface{} if it implements iface.
+func marshalerValue(val reflect.Value, iface reflect.Type) (interface{}, bool) {
+	if !val.IsValid() {
+		return nil, false
+	}
+	typ := val.Type()
+	if typ.Implements(iface) && val.CanInterface() {
+		return val.Interface(), true
+	}
+	if val.CanAddr() && val.Addr().Type().Implements(iface) {
+		return val.Addr().Interface(), true
+	}
+	if reflect.PointerTo(typ).Implements(iface) {
+		p := reflect.New(typ)
+		p.Elem().Set(val)
+		return p.Interface(), true
+	}
+	return nil, false
+}
+
+func joinPath(base, child string) string {
+	return base + "/" + child
+}
+
+func jsonFieldName(field reflect.StructField) (string, bool, bool) {
+	tag := field.Tag.Get("json")
+	if tag == "-" {
+		return "", false, true
+	}
+
+	parts := strings.Split(tag, ",")
+	name := field.Name
+	if len(parts) > 0 && parts[0] != "" {
+		name = parts[0]
+	}
+
+	omitEmpty := false
+	for _, opt := range parts[1:] {
+		if opt == "omitempty" {
+			omitEmpty = true
+			break
+		}
+	}
+
+	return name, omitEmpty, false
+}
+
+func isEmptyJSONValue(val reflect.Value) bool {
+	if !val.IsValid() {
+		return true
+	}
 
 	switch val.Kind() {
-	case reflect.Map:
-		iter := val.MapRange()
-		for iter.Next() {
-			key := iter.Key()
-			val := iter.Value()
-			if !val.CanInterface() {
-				continue
-			}
-			strKey := key.String()
-			if reKeyName.MatchString(path) {
-				strKey = stripDocker(strKey)
-			}
-			walk(kv, path+"/"+strKey, val.Interface(), strKey)
-		}
-
-	case reflect.Struct:
-		num := val.NumField()
-		for i := 0; i < num; i++ {
-			val := val.Field(i)
-			if !val.CanInterface() {
-				continue
-			}
-			walk(kv, path, val.Interface(), pos)
-		}
-
-	case reflect.Slice:
-		n := val.Len()
-		for i := 0; i < n; i++ {
-			val := val.Index(i)
-			if !val.CanInterface() {
-				continue
-			}
-			walk(kv, fmt.Sprintf("%s/%d", path, i), val.Interface(), pos)
-		}
-
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.String, reflect.Bool:
-
-		// stringify it
-		kv.add(stringify(val.Interface()), path)
-
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return val.Len() == 0
+	case reflect.Bool:
+		return !val.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return val.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return val.Uint() == 0
 	case reflect.Float32, reflect.Float64:
-		kv.add(stringifyFloat(val.Float()), path)
-
+		return val.Float() == 0
+	case reflect.Interface, reflect.Pointer:
+		return val.IsNil()
 	default:
-		log.Warn().Msgf("unhandled kind %s: %#v\n", val.Kind(), obj)
+		return false
 	}
-
-}
-
-func stringify(val interface{}) string {
-	return fmt.Sprintf("%v", val)
-}
-
-func stringifyFloat(val float64) string {
-	return strconv.FormatFloat(val, 'f', -1, 64)
 }

--- a/kv_test.go
+++ b/kv_test.go
@@ -42,27 +42,3 @@ func dumpKV(kv map[string]interface{}) {
 		fmt.Printf("%s = %s\n", k, v)
 	}
 }
-
-func Test_stringify(t *testing.T) {
-	v := 15552000
-	s := stringify(v)
-	require.Equal(t, "15552000", s, "int should match")
-
-	b := false
-	s = stringify(b)
-	require.Equal(t, "false", s, "bool should match")
-
-	b = true
-	s = stringify(b)
-	require.Equal(t, "true", s, "bool should match")
-}
-
-func Test_stringifyFloat(t *testing.T) {
-	f := float64(15552000)
-	s := stringifyFloat(f)
-	require.Equal(t, "15552000", s, "float should match")
-
-	f32 := float32(15552000)
-	s = stringifyFloat(float64(f32))
-	require.Equal(t, "15552000", s, "float should match")
-}

--- a/kv_walk_test.go
+++ b/kv_walk_test.go
@@ -1,0 +1,55 @@
+package traefikkop
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	ptypes "github.com/traefik/paerser/types"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+)
+
+func TestConfigToKVAllowEmptyLabel(t *testing.T) {
+	cfg := dynamic.Configuration{
+		HTTP: &dynamic.HTTPConfiguration{
+			Routers: map[string]*dynamic.Router{
+				"musicassistant@docker": {
+					Rule:        "Host(`musicassistant.example.com`)",
+					Service:     "musicassistant",
+					EntryPoints: []string{"websecure"},
+					TLS:         &dynamic.RouterTLSConfig{},
+				},
+			},
+		},
+		TCP: &dynamic.TCPConfiguration{},
+		UDP: &dynamic.UDPConfiguration{},
+		TLS: &dynamic.TLSConfiguration{},
+	}
+
+	got, err := ConfigToKV(cfg)
+	require.NoError(t, err)
+	require.Equal(t, "true", got["traefik/http/routers/musicassistant/tls"])
+}
+
+func TestConfigToKVUsesJSONLeafEncoding(t *testing.T) {
+	cfg := dynamic.Configuration{
+		HTTP: &dynamic.HTTPConfiguration{
+			Services: map[string]*dynamic.Service{
+				"musicassistant@docker": {
+					LoadBalancer: &dynamic.ServersLoadBalancer{
+						ResponseForwarding: &dynamic.ResponseForwarding{
+							FlushInterval: ptypes.Duration(5 * time.Second),
+						},
+					},
+				},
+			},
+		},
+		TCP: &dynamic.TCPConfiguration{},
+		UDP: &dynamic.UDPConfiguration{},
+		TLS: &dynamic.TLSConfiguration{},
+	}
+
+	got, err := ConfigToKV(cfg)
+	require.NoError(t, err)
+	require.Equal(t, "5s", got["traefik/http/services/musicassistant/loadBalancer/responseForwarding/flushInterval"])
+}


### PR DESCRIPTION
The previous impl was relying on an intermediate JSON step which got us close but missed a few values. Turns out there were some struct tags that converted an empty field into a 'true' rather than drop it completely as happened with the JSON encoder. New impl supports these cases.

Resolves #87