### PR TITLE
feat: add Redis Sentinel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ them to a given `redis` instance. Simply configure your `traefik` node with a
   - [Contents](#contents)
   - [Usage](#usage)
   - [Configuration](#configuration)
+  - [Redis Sentinel](#redis-sentinel)
   - [IP Binding](#ip-binding)
     - [bind-ip](#bind-ip)
     - [bind-interface](#bind-interface)
@@ -122,8 +123,10 @@ GLOBAL OPTIONS:
    --redis-user value     Redis username (default: "default") [$REDIS_USER]
    --redis-pass value     Redis password (if needed) [$REDIS_PASS]
    --redis-db value       Redis DB number (default: 0) [$REDIS_DB]
-   --redis-ttl value      Redis TTL (in seconds) (default: 0) [$REDIS_TTL]
-   --docker-host value    Docker endpoint (default: "unix:///var/run/docker.sock") [$DOCKER_ADDR]
+   --redis-ttl value              Redis TTL (in seconds) (default: 0) [$REDIS_TTL]
+   --redis-sentinel-addrs value   Comma-separated list of Redis Sentinel addresses (e.g., host1:26379,host2:26379) [$REDIS_SENTINEL_ADDRS]
+   --redis-sentinel-master value  Redis Sentinel master name [$REDIS_SENTINEL_MASTER]
+   --docker-host value            Docker endpoint (default: "unix:///var/run/docker.sock") [$DOCKER_ADDR]
    --docker-config value  Docker provider config (file must end in .yaml) [$DOCKER_CONFIG]
    --docker-prefix value  Docker label prefix [$DOCKER_PREFIX]
    --poll-interval value  Poll interval for refreshing container list (default: 60) [$KOP_POLL_INTERVAL]
@@ -134,6 +137,31 @@ GLOBAL OPTIONS:
 ```
 
 Most important are the `bind-ip`/`bind-interface` and `redis-addr` flags.
+
+## Redis Sentinel
+
+If your Redis setup uses [Sentinel](https://redis.io/docs/management/sentinel/)
+for high availability, you can configure `traefik-kop` to connect through
+Sentinel instead of directly to a Redis instance. This ensures `traefik-kop`
+always writes to the current master, even after a failover.
+
+```yaml
+services:
+  traefik-kop:
+    image: "ghcr.io/jittering/traefik-kop:latest"
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - "REDIS_SENTINEL_ADDRS=sentinel1:26379,sentinel2:26379,sentinel3:26379"
+      - "REDIS_SENTINEL_MASTER=mymaster"
+      - "BIND_IP=192.168.1.75"
+```
+
+When Sentinel is configured, the `--redis-addr` flag is ignored.
+Both `--redis-sentinel-addrs` and `--redis-sentinel-master` must be provided
+together. The `--redis-user`, `--redis-pass`, and `--redis-db` flags still apply
+and are used for authenticating with the Redis master discovered by Sentinel.
 
 ## IP Binding
 

--- a/bin/traefik-kop/main.go
+++ b/bin/traefik-kop/main.go
@@ -106,6 +106,16 @@ func flags() {
 				EnvVars: []string{"REDIS_TTL"},
 			},
 			&cli.StringFlag{
+				Name:    "redis-sentinel-addrs",
+				Usage:   "Comma-separated list of Redis Sentinel addresses (e.g., host1:26379,host2:26379)",
+				EnvVars: []string{"REDIS_SENTINEL_ADDRS"},
+			},
+			&cli.StringFlag{
+				Name:    "redis-sentinel-master",
+				Usage:   "Redis Sentinel master name",
+				EnvVars: []string{"REDIS_SENTINEL_MASTER"},
+			},
+			&cli.StringFlag{
 				Name:    "docker-host",
 				Usage:   "Docker endpoint",
 				Value:   defaultDockerHost,
@@ -192,24 +202,35 @@ func doStart(c *cli.Context) error {
 		bindIP = getDefaultIP(iface)
 	}
 
+	sentinelAddrs := splitStringArr(c.String("redis-sentinel-addrs"))
+
 	config := traefikkop.Config{
-		Hostname:     c.String("hostname"),
-		BindIP:       bindIP,
-		SkipReplace:  c.Bool("skip-replace"),
-		RedisAddr:    c.String("redis-addr"),
-		RedisUser:    c.String("redis-user"),
-		RedisPass:    c.String("redis-pass"),
-		RedisDB:      c.Int("redis-db"),
-		RedisTTL:     c.Int("redis-ttl"),
-		DockerHost:   c.String("docker-host"),
-		DockerConfig: c.String("docker-config"),
-		DockerPrefix: c.String("docker-prefix"),
-		PollInterval: c.Int64("poll-interval"),
-		Namespace:    namespaces,
+		Hostname:            c.String("hostname"),
+		BindIP:              bindIP,
+		SkipReplace:         c.Bool("skip-replace"),
+		RedisAddr:           c.String("redis-addr"),
+		RedisUser:           c.String("redis-user"),
+		RedisPass:           c.String("redis-pass"),
+		RedisDB:             c.Int("redis-db"),
+		RedisTTL:            c.Int("redis-ttl"),
+		RedisSentinelAddrs:  sentinelAddrs,
+		RedisSentinelMaster: c.String("redis-sentinel-master"),
+		DockerHost:          c.String("docker-host"),
+		DockerConfig:        c.String("docker-config"),
+		DockerPrefix:        c.String("docker-prefix"),
+		PollInterval:        c.Int64("poll-interval"),
+		Namespace:           namespaces,
 	}
 
 	if config.BindIP == "" {
 		log.Fatal().Msg("Bind IP cannot be empty")
+	}
+
+	if len(config.RedisSentinelAddrs) > 0 && config.RedisSentinelMaster == "" {
+		log.Fatal().Msg("--redis-sentinel-master is required when using --redis-sentinel-addrs")
+	}
+	if config.RedisSentinelMaster != "" && len(config.RedisSentinelAddrs) == 0 {
+		log.Fatal().Msg("--redis-sentinel-addrs is required when using --redis-sentinel-master")
 	}
 
 	if os.Getenv("DOCKER_HOST") != "" {

--- a/config.go
+++ b/config.go
@@ -26,6 +26,11 @@ type Config struct {
 	RedisUser    string
 	RedisPass    string
 	RedisDB      int
+
+	// Redis Sentinel
+	RedisSentinelAddrs  []string
+	RedisSentinelMaster string
+
 	PollInterval int64
 	Namespace    []string
 }

--- a/store.go
+++ b/store.go
@@ -43,21 +43,35 @@ type RedisStore struct {
 	lastConfig *dynamic.Configuration
 }
 
-func NewRedisStore(hostname string, addr string, ttl int, user string, pass string, db int) TraefikStore {
-	log.Info().Msgf("creating new redis store at %s for hostname %s with %dsec TTL", addr, hostname, ttl)
+func NewRedisStore(hostname string, addr string, ttl int, user string, pass string, db int, sentinelAddrs []string, sentinelMaster string) TraefikStore {
+	var client *redis.Client
 
-	store := &RedisStore{
-		Hostname: hostname,
-		TTL:      time.Duration(ttl) * time.Second,
-
-		client: redis.NewClient(&redis.Options{
+	if len(sentinelAddrs) > 0 && sentinelMaster != "" {
+		log.Info().Msgf("creating new redis store via sentinel (master=%s, sentinels=%v) for hostname %s with %dsec TTL", sentinelMaster, sentinelAddrs, hostname, ttl)
+		client = redis.NewFailoverClient(&redis.FailoverOptions{
+			MasterName:      sentinelMaster,
+			SentinelAddrs:   sentinelAddrs,
+			DisableIdentity: true,
+			Username:        user,
+			Password:        pass,
+			DB:              db,
+		})
+	} else {
+		log.Info().Msgf("creating new redis store at %s for hostname %s with %dsec TTL", addr, hostname, ttl)
+		client = redis.NewClient(&redis.Options{
 			ClientName:      "",
 			DisableIdentity: true,
 			Addr:            addr,
 			Username:        user,
 			Password:        pass,
 			DB:              db,
-		}),
+		})
+	}
+
+	store := &RedisStore{
+		Hostname: hostname,
+		TTL:      time.Duration(ttl) * time.Second,
+		client:   client,
 	}
 	return store
 }

--- a/store_test.go
+++ b/store_test.go
@@ -54,7 +54,7 @@ func Test_redisStore(t *testing.T) {
 	go server.Start()
 	defer server.ShutDown()
 
-	store := NewRedisStore("localhost", fmt.Sprintf("localhost:%d", port), 0, "", "", 0)
+	store := NewRedisStore("localhost", fmt.Sprintf("localhost:%d", port), 0, "", "", 0, nil, "")
 	processFileWithConfig(t, store, nil, "hellodetect.yml")
 	assertServiceIPs(t, store, []svc{
 		{"hello-detect", "http", "http://192.168.100.100:5577"},

--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -111,9 +111,12 @@ func Start(config Config) {
 	}
 
 	dp := newDockerProvider(config)
-	store := NewRedisStore(config.Hostname, config.RedisAddr, config.RedisTTL, config.RedisUser, config.RedisPass, config.RedisDB)
+	store := NewRedisStore(config.Hostname, config.RedisAddr, config.RedisTTL, config.RedisUser, config.RedisPass, config.RedisDB, config.RedisSentinelAddrs, config.RedisSentinelMaster)
 	err = store.Ping()
 	if err != nil {
+		if len(config.RedisSentinelAddrs) > 0 {
+			log.Fatal().Msgf("failed to connect to redis via sentinel (master=%s): %s", config.RedisSentinelMaster, err)
+		}
 		if strings.Contains(err.Error(), config.RedisAddr) {
 			log.Fatal().Msgf("failed to connect to redis: %s", err)
 		}


### PR DESCRIPTION
## Summary

Adds support for connecting to Redis through Sentinel, enabling automatic master discovery and failover. This is useful when running traefik-kop alongside a Redis Sentinel cluster (e.g., in Docker Swarm), where the master instance can change dynamically.

- New flags: `--redis-sentinel-addrs` and `--redis-sentinel-master`
- Uses go-redis `NewFailoverClient` which already ships with v9
- No new dependencies
- Fully backward compatible

## Motivation

When using traefik's Redis provider with Sentinel (`providers.redis.sentinel`), traefik follows master failovers automatically. However, traefik-kop writes directly to a fixed Redis address, which breaks after a Sentinel failover since kop may end up writing to a read-only replica. This PR aligns kop's Redis connection strategy with traefik's.

## Usage

```yaml
environment:
  - "REDIS_SENTINEL_ADDRS=sentinel1:26379,sentinel2:26379,sentinel3:26379"
  - "REDIS_SENTINEL_MASTER=mymaster"
