### PR TITLE
Feature/traefik v3 kv store support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,19 @@ GLOBAL OPTIONS:
    --docker-prefix value  Docker label prefix [$DOCKER_PREFIX]
    --poll-interval value  Poll interval for refreshing container list (default: 60) [$KOP_POLL_INTERVAL]
    --namespace value      Namespace to process containers for [$NAMESPACE]
+   --traefik-version value Target Traefik KV format version (2 or 3) (default: 3) [$TRAEFIK_VERSION]
    --verbose              Enable debug logging (default: false) [$VERBOSE, $DEBUG]
    --help, -h             show help
    --version, -V          Print the version (default: false)
 ```
 
 Most important are the `bind-ip`/`bind-interface` and `redis-addr` flags.
+
+### Traefik Version
+
+By default, `traefik-kop` outputs data in a format compatible with Traefik v3's KV store. Specifically, this ensures that arrays (such as `entryPoints` or `middlewares`) are serialized as comma-separated strings instead of numerically-indexed keys.
+
+If you are using Traefik v2 and encounter issues with array properties not being parsed, you can revert to the legacy behavior by setting the `--traefik-version=2` flag or the `TRAEFIK_VERSION=2` environment variable.
 
 ## IP Binding
 

--- a/bin/traefik-kop/main.go
+++ b/bin/traefik-kop/main.go
@@ -138,6 +138,12 @@ func flags() {
 				Value:   false,
 				EnvVars: []string{"VERBOSE", "DEBUG"},
 			},
+			&cli.IntFlag{
+				Name:    "traefik-version",
+				Usage:   "Target Traefik KV format version (2 or 3)",
+				Value:   3,
+				EnvVars: []string{"TRAEFIK_VERSION"},
+			},
 		},
 	}
 
@@ -203,9 +209,10 @@ func doStart(c *cli.Context) error {
 		RedisTTL:     c.Int("redis-ttl"),
 		DockerHost:   c.String("docker-host"),
 		DockerConfig: c.String("docker-config"),
-		DockerPrefix: c.String("docker-prefix"),
-		PollInterval: c.Int64("poll-interval"),
-		Namespace:    namespaces,
+		DockerPrefix:   c.String("docker-prefix"),
+		PollInterval:   c.Int64("poll-interval"),
+		Namespace:      namespaces,
+		TraefikVersion: c.Int("traefik-version"),
 	}
 
 	if config.BindIP == "" {

--- a/config.go
+++ b/config.go
@@ -26,8 +26,9 @@ type Config struct {
 	RedisUser    string
 	RedisPass    string
 	RedisDB      int
-	PollInterval int64
-	Namespace    []string
+	PollInterval   int64
+	Namespace      []string
+	TraefikVersion int
 }
 
 type ConfigFile struct {

--- a/docker_helpers_test.go
+++ b/docker_helpers_test.go
@@ -74,7 +74,7 @@ func (s *testStore) Gets(key string) (map[string]string, error) {
 }
 
 func (s *testStore) Store(conf dynamic.Configuration) error {
-	kv, err := ConfigToKV(conf)
+	kv, err := ConfigToKV(conf, 3)
 	if err != nil {
 		return err
 	}

--- a/kv.go
+++ b/kv.go
@@ -13,8 +13,9 @@ import (
 )
 
 type KV struct {
-	data map[string]interface{}
-	base string
+	data           map[string]interface{}
+	base           string
+	traefikVersion int
 }
 
 func NewKV() *KV {
@@ -48,8 +49,9 @@ func (kv *KV) add(val interface{}, format string, a ...interface{}) {
 
 // ConfigToKV flattens the given configuration into a format suitable for
 // putting into a KV store such as redis
-func ConfigToKV(conf dynamic.Configuration) (map[string]interface{}, error) {
+func ConfigToKV(conf dynamic.Configuration, traefikVersion int) (map[string]interface{}, error) {
 	kv := NewKV()
+	kv.traefikVersion = traefikVersion
 	_, err := walkTypedValue(kv, "traefik", reflect.TypeOf(conf), reflect.ValueOf(conf), walkOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kv: %w", err)
@@ -196,6 +198,15 @@ func walkSliceValue(kv *KV, path string, typ reflect.Type, val reflect.Value) (b
 
 	if val.Len() == 0 {
 		return false, nil
+	}
+
+	if kv.traefikVersion >= 3 && typ.Elem().Kind() == reflect.String {
+		var parts []string
+		for i := 0; i < val.Len(); i++ {
+			parts = append(parts, val.Index(i).String())
+		}
+		kv.add(strings.Join(parts, ","), path)
+		return true, nil
 	}
 
 	addedAny := false

--- a/kv_test.go
+++ b/kv_test.go
@@ -15,7 +15,7 @@ func Test_configToKV(t *testing.T) {
 	_, err := toml.DecodeFile("./fixtures/sample.toml", &cfg)
 	require.NoError(t, err)
 
-	got, err := ConfigToKV(*cfg)
+	got, err := ConfigToKV(*cfg, 3)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 
@@ -28,7 +28,7 @@ func Test_configToKV(t *testing.T) {
 	err = json.Unmarshal([]byte(NGINX_CONF_JSON), cfg)
 	require.NoError(t, err)
 
-	got, err = ConfigToKV(*cfg)
+	got, err = ConfigToKV(*cfg, 3)
 	require.NoError(t, err)
 	// dumpKV(got)
 	require.NotContains(t, got, "traefik/http/routers/nginx@docker/service")

--- a/kv_walk_test.go
+++ b/kv_walk_test.go
@@ -26,7 +26,7 @@ func TestConfigToKVAllowEmptyLabel(t *testing.T) {
 		TLS: &dynamic.TLSConfiguration{},
 	}
 
-	got, err := ConfigToKV(cfg)
+	got, err := ConfigToKV(cfg, 3)
 	require.NoError(t, err)
 	require.Equal(t, "true", got["traefik/http/routers/musicassistant/tls"])
 }
@@ -49,7 +49,7 @@ func TestConfigToKVUsesJSONLeafEncoding(t *testing.T) {
 		TLS: &dynamic.TLSConfiguration{},
 	}
 
-	got, err := ConfigToKV(cfg)
+	got, err := ConfigToKV(cfg, 3)
 	require.NoError(t, err)
 	require.Equal(t, "5s", got["traefik/http/services/musicassistant/loadBalancer/responseForwarding/flushInterval"])
 }

--- a/store.go
+++ b/store.go
@@ -39,11 +39,12 @@ type RedisStore struct {
 	Hostname string
 	TTL      time.Duration // TTL in seconds, 0 means no TTL
 
-	client     *redis.Client
-	lastConfig *dynamic.Configuration
+	client         *redis.Client
+	lastConfig     *dynamic.Configuration
+	traefikVersion int
 }
 
-func NewRedisStore(hostname string, addr string, ttl int, user string, pass string, db int) TraefikStore {
+func NewRedisStore(hostname string, addr string, ttl int, user string, pass string, db int, traefikVersion int) TraefikStore {
 	log.Info().Msgf("creating new redis store at %s for hostname %s with %dsec TTL", addr, hostname, ttl)
 
 	store := &RedisStore{
@@ -58,6 +59,7 @@ func NewRedisStore(hostname string, addr string, ttl int, user string, pass stri
 			Password:        pass,
 			DB:              db,
 		}),
+		traefikVersion: traefikVersion,
 	}
 	return store
 }
@@ -117,7 +119,7 @@ func (s *RedisStore) Store(conf dynamic.Configuration) error {
 	s.removeOldKeys(conf.UDP.Routers, "udp_routers")
 	s.removeOldKeys(conf.UDP.Services, "udp_services")
 
-	kv, err := ConfigToKV(conf)
+	kv, err := ConfigToKV(conf, s.traefikVersion)
 	if err != nil {
 		return err
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -54,7 +54,7 @@ func Test_redisStore(t *testing.T) {
 	go server.Start()
 	defer server.ShutDown()
 
-	store := NewRedisStore("localhost", fmt.Sprintf("localhost:%d", port), 0, "", "", 0)
+	store := NewRedisStore("localhost", fmt.Sprintf("localhost:%d", port), 0, "", "", 0, 3)
 	processFileWithConfig(t, store, nil, "hellodetect.yml")
 	assertServiceIPs(t, store, []svc{
 		{"hello-detect", "http", "http://192.168.100.100:5577"},

--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -111,7 +111,7 @@ func Start(config Config) {
 	}
 
 	dp := newDockerProvider(config)
-	store := NewRedisStore(config.Hostname, config.RedisAddr, config.RedisTTL, config.RedisUser, config.RedisPass, config.RedisDB)
+	store := NewRedisStore(config.Hostname, config.RedisAddr, config.RedisTTL, config.RedisUser, config.RedisPass, config.RedisDB, config.TraefikVersion)
 	err = store.Ping()
 	if err != nil {
 		if strings.Contains(err.Error(), config.RedisAddr) {


### PR DESCRIPTION
***

Add support for Traefik v3 KV store formatting

### Description
This PR addresses a breaking compatibility issue when using `traefik-kop` as a provider for a Traefik v3 proxy. 

Traefik v3 removed support for numerically-indexed slices in its Key-Value providers (e.g., `traefik/http/routers/my-app/entryPoints/0 = "https"`). Slices of strings are now expected to be formatted as a single comma-separated value string (e.g., `traefik/http/routers/my-app/entryPoints = "http,https"`). Because `traefik-kop` was still using the v2 indexed logic, Traefik v3 would silently drop array properties like `entryPoints` and `middlewares`, leading to TLS handshakes failing and `404` errors.

### What's changed
- **Version Flag:** Introduced a `--traefik-version` CLI flag and `TRAEFIK_VERSION` environment variable.
- **V3 Default:** Because `go.mod` is tracking Traefik v3, the default `TRAEFIK_VERSION` is now `3`. Legacy users can still pass `TRAEFIK_VERSION=2` to retain the old indexed formatting.
- **Slice Serialization:** Updated `walkSliceValue` in `kv.go` to intercept string arrays and join them with commas if `traefikVersion >= 3`.
- **Documentation:** Updated `README.md` to document the new environment variable and the version compatibility toggle.

### Testing
- Validated that `entryPoints` and `tls` are correctly written to Redis without the trailing `/0` indices.
- All unit tests have been updated and are passing successfully.

```
  sudo docker exec -it redis redis-cli keys "*tls*"
  1) "traefik/http/routers/pihole/tls"
  2) "traefik/http/routers/my-app/tls"
  sudo docker exec -it redis redis-cli keys "*entryPoints*"
  1) "traefik/http/routers/my-app/entryPoints"
  2) "traefik/http/routers/pihole/entryPoints"
```

*** 