### PR TITLE
feat: Resolve internal port to host ports

### DIFF
--- a/bin/traefik-kop/main.go
+++ b/bin/traefik-kop/main.go
@@ -148,6 +148,12 @@ func flags() {
 				Value:   false,
 				EnvVars: []string{"VERBOSE", "DEBUG"},
 			},
+			&cli.BoolFlag{
+				Name:    "resolve-internal-ports",
+				Usage:   "Resolve the internal port to the host port for service",
+				Value:   false,
+				EnvVars: []string{"RESOLVE_INTERNAL_PORTS"},
+			},
 		},
 	}
 
@@ -205,21 +211,22 @@ func doStart(c *cli.Context) error {
 	sentinelAddrs := splitStringArr(c.String("redis-sentinel-addrs"))
 
 	config := traefikkop.Config{
-		Hostname:            c.String("hostname"),
-		BindIP:              bindIP,
-		SkipReplace:         c.Bool("skip-replace"),
-		RedisAddr:           c.String("redis-addr"),
-		RedisUser:           c.String("redis-user"),
-		RedisPass:           c.String("redis-pass"),
-		RedisDB:             c.Int("redis-db"),
-		RedisTTL:            c.Int("redis-ttl"),
-		RedisSentinelAddrs:  sentinelAddrs,
-		RedisSentinelMaster: c.String("redis-sentinel-master"),
-		DockerHost:          c.String("docker-host"),
-		DockerConfig:        c.String("docker-config"),
-		DockerPrefix:        c.String("docker-prefix"),
-		PollInterval:        c.Int64("poll-interval"),
-		Namespace:           namespaces,
+		Hostname:             c.String("hostname"),
+		BindIP:               bindIP,
+		SkipReplace:          c.Bool("skip-replace"),
+		RedisAddr:            c.String("redis-addr"),
+		RedisUser:            c.String("redis-user"),
+		RedisPass:            c.String("redis-pass"),
+		RedisDB:              c.Int("redis-db"),
+		RedisTTL:             c.Int("redis-ttl"),
+		RedisSentinelAddrs:   sentinelAddrs,
+		RedisSentinelMaster:  c.String("redis-sentinel-master"),
+		DockerHost:           c.String("docker-host"),
+		DockerConfig:         c.String("docker-config"),
+		DockerPrefix:         c.String("docker-prefix"),
+		PollInterval:         c.Int64("poll-interval"),
+		Namespace:            namespaces,
+		ResolveInternalPorts: c.Bool("resolve-internal-ports"),
 	}
 
 	if config.BindIP == "" {

--- a/config.go
+++ b/config.go
@@ -31,8 +31,9 @@ type Config struct {
 	RedisSentinelAddrs  []string
 	RedisSentinelMaster string
 
-	PollInterval int64
-	Namespace    []string
+	PollInterval         int64
+	Namespace            []string
+	ResolveInternalPorts bool
 }
 
 type ConfigFile struct {

--- a/docker.go
+++ b/docker.go
@@ -140,16 +140,24 @@ func isPortSet(container container.InspectResponse, svcType string, svcName stri
 // If more than one port is bound (e.g., for a service like minio), then this
 // detection will fail. Instead, the user should explicitly set the port in the
 // label.
-func getPortBinding(container container.InspectResponse) (string, error) {
+func getPortBinding(container container.InspectResponse, protocol string) (string, error) {
 	log.Debug().Msg("looking for port in host config bindings")
-	numBindings := len(container.HostConfig.PortBindings)
-	log.Debug().Msgf("found %d host-port bindings", numBindings)
-	if numBindings > 1 {
-		return "", errors.Errorf("found more than one host-port binding for container '%s' (%s)", container.Name, portBindingString(container.HostConfig.PortBindings))
+
+	protocolBindings := make(nat.PortMap)
+	for bindPort, bindings := range container.HostConfig.PortBindings {
+		if bindPort.Proto() == protocol {
+			protocolBindings[bindPort] = bindings
+		}
 	}
-	for _, v := range container.HostConfig.PortBindings {
+	log.Debug().Msgf("found %d %s host-port bindings", len(protocolBindings), protocol)
+
+	if len(protocolBindings) > 1 {
+		return "", errors.Errorf("found more than one %s host-port binding for container '%s' (%s)", protocol, container.Name, portBindingString(protocolBindings))
+	}
+
+	for _, v := range protocolBindings {
 		if len(v) > 1 {
-			return "", errors.Errorf("found more than one host-port binding for container '%s' (%s)", container.Name, portBindingString(container.HostConfig.PortBindings))
+			return "", errors.Errorf("found more than one host-port binding for container '%s' (%s)", container.Name, portBindingString(protocolBindings))
 		}
 		if v[0].HostPort != "" {
 			log.Debug().Msgf("found host-port binding %s", v[0].HostPort)
@@ -160,7 +168,10 @@ func getPortBinding(container container.InspectResponse) (string, error) {
 	// check for a randomly set port via --publish-all
 	if container.NetworkSettings != nil && len(container.NetworkSettings.Ports) == 1 {
 		log.Debug().Msg("looking for [randomly set] port in network settings")
-		for _, v := range container.NetworkSettings.Ports {
+		for k, v := range container.NetworkSettings.Ports {
+			if k.Proto() != protocol {
+				continue
+			}
 			if len(v) > 0 {
 				port := v[0].HostPort
 				if port != "" {

--- a/docker.go
+++ b/docker.go
@@ -129,6 +129,95 @@ func isPortSet(container container.InspectResponse, svcType string, svcName stri
 	return container.Config.Labels[needle]
 }
 
+// isKopInternalPortSet checks the docker container config for an internal port set via label
+//
+// # Returns the host port for the internal set port
+//
+// i.e., it looks for the following from a docker-compose service:
+//
+// ports:
+//   - "5555:55"
+//
+// labels:
+//   - "kop.<svcType>.services.<svcName>.resolve-port=55"
+//
+// if the label "kop.<svcType>.services.<svcName>.resolve-port" is set, returns the host port
+// for the internal port, so here it would return "5555"
+func isKopInternalPortSet(container container.InspectResponse, svcType string, svcName string, routerName string) string {
+	log.Debug().Msg("looking for the internal port in host config bindings")
+	numBindings := len(container.HostConfig.PortBindings)
+	log.Debug().Msgf("found %d host-port bindings", numBindings)
+
+	// When no service defined traefik generates name.
+	// So we use the routername for the kop label lookup
+	if routerName != svcName {
+		svcName = routerName
+	}
+
+	svcName = stripDocker(svcName)
+	needle := fmt.Sprintf("kop.%s.services.%s.resolve-port", svcType, svcName)
+	internalPort := container.Config.Labels[needle]
+
+	if internalPort == "" {
+		log.Debug().Msgf("no kop internal port found for %s/%s", svcType, svcName)
+		return ""
+	}
+	log.Debug().Msgf("found kop internal port '%s' now resolving to host port", internalPort)
+
+	return getHostPort(container, getSvcProtocol(svcType), internalPort)
+}
+
+// getHostPort checks the docker container config for the internal port of the service
+//
+// i.e., it looks for the following from a docker-compose service:
+//
+// ports:
+//   - 5555:55
+//   - 6666:66
+//
+// Searches for the port specified by `port` and returns the host port if found.
+// For example, if `port` is "55", returns "5555".
+func getHostPort(container container.InspectResponse, protocol string, internalPort string) string {
+	log.Debug().Msgf("looking for internal port %s in host config bindings", internalPort)
+
+	protocolBindings := make(nat.PortMap)
+	for bindPort, bindings := range container.HostConfig.PortBindings {
+		if bindPort.Proto() == protocol {
+			protocolBindings[bindPort] = bindings
+		}
+	}
+	log.Debug().Msgf("found %d %s host-port bindings", len(protocolBindings), protocol)
+
+	for k, v := range protocolBindings {
+		if len(v) == 0 {
+			continue
+		}
+
+		if k.Port() == internalPort && v[0].HostPort != "" {
+			log.Debug().Msgf("found host-port binding %s for internal port %s", v[0].HostPort, internalPort)
+			return v[0].HostPort
+		}
+	}
+
+	if container.NetworkSettings != nil && len(container.NetworkSettings.Ports) > 0 {
+		log.Debug().Msgf("looking for [randomly set] host port in network settings for internal port %s", internalPort)
+		for k, v := range container.NetworkSettings.Ports {
+			if len(v) == 0 || k.Proto() != protocol {
+				continue
+			}
+			if k.Port() == internalPort && v[0].HostPort != "" {
+				if len(v) > 1 {
+					log.Warn().Msgf("found %d host-port bindings for internal port %s, using the first one", len(v), internalPort)
+				}
+				return v[0].HostPort
+			}
+		}
+	}
+
+	log.Error().Msgf("no host-port binding found for internal port %s", internalPort)
+	return ""
+}
+
 // getPortBinding checks the docker container config for a port binding for the
 // service. Currently this will only work if a single port is mapped/exposed.
 //

--- a/store_test.go
+++ b/store_test.go
@@ -16,6 +16,8 @@ import (
 
 const NGINX_CONF_JSON = `{"http":{"routers":{"nginx@docker":{"service":"nginx","rule":"Host('nginx.local')"}},"services":{"nginx@docker":{"loadBalancer":{"servers":[{"url":"http://172.20.0.2:80"}],"passHostHeader":true}}}},"tcp":{},"udp":{},"tls":{"options":{"default":{"clientAuth":{},"alpnProtocols":["h2","http/1.1","acme-tls/1"]}}}}`
 const NGINX_CONF_JSON_DIFFRENT_SERVICE_NAME = `{"http":{"routers":{"nginx@docker":{"service":"nginx-nginx","rule":"Host('nginx.local')"}},"services":{"nginx-nginx@docker":{"loadBalancer":{"servers":[{"url":"http://172.20.0.2:80"}],"passHostHeader":true}}}},"tcp":{},"udp":{},"tls":{"options":{"default":{"clientAuth":{},"alpnProtocols":["h2","http/1.1","acme-tls/1"]}}}}`
+const NGINX_CONF_JSON_TCP = `{"http":{},"tcp":{"routers":{"nginx-tcp@docker":{"service":"nginx-tcp","rule":"HostSNI('nginx.local')"}},"services":{"nginx-tcp@docker":{"loadBalancer":{"servers":[{"address":"172.20.0.2:80"}]}}}},"udp":{},"tls":{"options":{"default":{"clientAuth":{},"alpnProtocols":["h2","http/2.1","acme-tls/1"]}}}}`
+const NGINX_CONF_JSON_UDP = `{"http":{},"tcp":{},"udp":{"routers":{"nginx-udp@docker":{"service":"nginx-udp"}},"services":{"nginx-udp@docker":{"loadBalancer":{"servers":[{"address":"172.20.0.2:90"}]}}}},"tls":{"options":{"default":{"clientAuth":{},"alpnProtocols":["h2","http/2.1","acme-tls/1"]}}}}`
 
 func Test_collectKeys(t *testing.T) {
 	cfg := &dynamic.Configuration{}

--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -3,6 +3,7 @@ package traefikkop
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -355,7 +356,14 @@ func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, defaultIp string, 
 				defaultIp = getContainerNetworkIP(dc, conf, "tcp", svcName, defaultIp)
 
 				server := &svc.LoadBalancer.Servers[i]
+				if server.Address != "" {
+					if _, p, err := net.SplitHostPort(server.Address); err == nil && p != "" {
+						server.Port = p
+					}
+				}
 				server.Port = getContainerPort(dc, conf, "tcp", svcName, server.Port, resolveInternalPorts)
+
+				server.Address = defaultIp
 				if server.Port != "" {
 					server.Address += ":" + server.Port
 				}
@@ -376,7 +384,14 @@ func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, defaultIp string, 
 				defaultIp = getContainerNetworkIP(dc, conf, "udp", svcName, defaultIp)
 
 				server := &svc.LoadBalancer.Servers[i]
+				if server.Address != "" {
+					if _, p, err := net.SplitHostPort(server.Address); err == nil && p != "" {
+						server.Port = p
+					}
+				}
 				server.Port = getContainerPort(dc, conf, "udp", svcName, server.Port, resolveInternalPorts)
+
+				server.Address = defaultIp
 				if server.Port != "" {
 					server.Address += ":" + server.Port
 				}

--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -442,9 +442,11 @@ func getRouterOfService(conf *dynamic.Configuration, svcName string, svcType str
 // traefik during its config parsing (possibly an container-internal port). The
 // purpose of this method is to see if we can find a better match, specifically
 // by looking at the host-port bindings in the docker config.
-func getContainerPort(dc *dockerCache, conf *dynamic.Configuration, svcType string, svcName string, port string) string {
+func getContainerPort(dc *dockerCache, conf *dynamic.Configuration, svcType string, svcName string, port string, resolveInternalPorts bool) string {
 	log := log.With().Str("service", svcName).Str("service-type", svcType).Logger()
-	container, err := dc.findContainerByServiceName(svcType, svcName, getRouterOfService(conf, svcName, svcType))
+	routerName := getRouterOfService(conf, svcName, svcType)
+
+	container, err := dc.findContainerByServiceName(svcType, svcName, routerName)
 	if err != nil {
 		log.Warn().Msgf("failed to find host-port: %s", err)
 		return port
@@ -455,6 +457,37 @@ func getContainerPort(dc *dockerCache, conf *dynamic.Configuration, svcType stri
 		log.Debug().Msgf("using internal kop label set port %s for %s", inp, svcName)
 		return inp
 	}
+
+	if explicitPort := isPortSet(container, svcType, svcName); explicitPort != "" {
+		if !resolveInternalPorts {
+			log.Debug().Str("port", explicitPort).Str("service", svcName).Msg("Using explicitly set port")
+			return explicitPort
+		}
+
+		log.Debug().Str("internalPort", explicitPort).Str("service", svcName).Msg("Using internal set port")
+
+		protocol := getSvcProtocol(svcType)
+		if hostPort := getHostPort(container, protocol, explicitPort); hostPort != "" {
+			log.Debug().Str("internalPort", explicitPort).Str("hostPort", hostPort).Msg("Overriding internal set port with host-port")
+			return hostPort
+		}
+
+		log.Warn().Str("internalPort", explicitPort).Msg("No host-port binding found for internal port, defaulting to internal port")
+		return explicitPort
+	}
+
+	if resolveInternalPorts && port != "" {
+		protocol := getSvcProtocol(svcType)
+		if hostPort := getHostPort(container, protocol, port); hostPort != "" {
+			log.Debug().Str("internalPort", port).Str("hostPort", hostPort).Str("service", svcName).Msg("Resolved internal port to host-port")
+			return hostPort
+		}
+
+		log.Debug().Str("internalPort", port).Msg("No host-port binding found for internal port, falling back")
+		return port
+	}
+
+	log.Debug().Msgf("ServiceType: %s, Protocol: %s", svcType, getSvcProtocol(svcType))
 	exposedPort, err := getPortBinding(container, getSvcProtocol(svcType))
 	if err != nil {
 		if strings.Contains(err.Error(), "no host-port binding") {

--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -429,6 +429,12 @@ func getContainerPort(dc *dockerCache, conf *dynamic.Configuration, svcType stri
 		log.Warn().Msgf("failed to find host-port: %s", err)
 		return port
 	}
+
+	log.Debug().Msgf("getting port %s for %s/%s", port, svcType, svcName)
+	if inp := isKopInternalPortSet(container, svcType, svcName, routerName); inp != "" {
+		log.Debug().Msgf("using internal kop label set port %s for %s", inp, svcName)
+		return inp
+	}
 	exposedPort, err := getPortBinding(container, getSvcProtocol(svcType))
 	if err != nil {
 		if strings.Contains(err.Error(), "no host-port binding") {

--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -429,11 +429,7 @@ func getContainerPort(dc *dockerCache, conf *dynamic.Configuration, svcType stri
 		log.Warn().Msgf("failed to find host-port: %s", err)
 		return port
 	}
-	if p := isPortSet(container, svcType, svcName); p != "" {
-		log.Debug().Msgf("using explicitly set port %s for %s", p, svcName)
-		return p
-	}
-	exposedPort, err := getPortBinding(container)
+	exposedPort, err := getPortBinding(container, getSvcProtocol(svcType))
 	if err != nil {
 		if strings.Contains(err.Error(), "no host-port binding") {
 			log.Debug().Err(err)
@@ -449,6 +445,18 @@ func getContainerPort(dc *dockerCache, conf *dynamic.Configuration, svcType stri
 	}
 	log.Debug().Msgf("overriding service port from container host-port: using %s (was %s) for %s", exposedPort, port, svcName)
 	return exposedPort
+}
+
+// getSvcProtocol returns the protocol for the given service type
+func getSvcProtocol(svcType string) string {
+	switch svcType {
+	case "tcp":
+		return "tcp"
+	case "udp":
+		return "udp"
+	default:
+		return "tcp"
+	}
 }
 
 // Gets the container IP when it is configured to use a network-routable address

--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -530,6 +530,53 @@ func getKopOverrideBinding(dc *dockerCache, conf *dynamic.Configuration, svcType
 	return hostIP, false
 }
 
+// getKopOverrideResolveInternalPort Check for explicit resolve-internal-ports override set via label
+//
+// Label can be one of two keys:
+// - kop.<svcType>.services.<svcName>.resolve-internal-ports = <true|false>
+// - kop.resolve-internal-ports = <true|false>
+//
+// If the label is not set, the default value is used (resolveInternalPorts).
+func getKopOverrideResolveInternalPort(dc *dockerCache, conf *dynamic.Configuration, svcType, svcName string, defaultResolveInternalPorts bool) (resolveInternalPorts bool, changed bool) {
+	routerName := getRouterOfService(conf, svcName, svcType)
+
+	container, err := dc.findContainerByServiceName(svcType, svcName, routerName)
+	if err != nil {
+		log.Debug().Msgf("failed to find container for service '%s': %s", svcName, err)
+		return defaultResolveInternalPorts, false
+	}
+
+	handleParse := func(labelResolvePorts string) (val bool, changed bool) {
+		labelResolvePortsBool, err := strconv.ParseBool(labelResolvePorts)
+		if err != nil {
+			log.Debug().Msgf("failed to parse resolve-internal-ports [%s] label for service '%s': %s", labelResolvePorts, svcName, err)
+			return defaultResolveInternalPorts, false
+		}
+		return labelResolvePortsBool, true
+	}
+
+	// When no service defined traefik generates name.
+	// So we use the routername for the kop label lookup
+	if routerName != svcName {
+		svcName = routerName
+	}
+
+	svcName = stripDocker(svcName)
+	svcNeedle := fmt.Sprintf("kop.%s.services.%s.resolve-internal-ports", svcType, svcName)
+	if labelResolvePorts := container.Config.Labels[svcNeedle]; labelResolvePorts != "" {
+		log.Debug().Msgf("found label %s with ResolveInternalPorts value '%s' for service %s", svcNeedle, labelResolvePorts, svcName)
+		return handleParse(labelResolvePorts)
+
+	}
+
+	if resolveInternalPorts := container.Config.Labels["kop.resolve-internal-ports"]; resolveInternalPorts != "" {
+		log.Debug().Msgf("found label %s with ResolveInternalPorts value '%s' for service %s", "kop.resolve-internal-ports", resolveInternalPorts, svcName)
+		return handleParse(resolveInternalPorts)
+	}
+
+	return defaultResolveInternalPorts, false
+}
+
 // mergeLoadBalancers merges load balancer servers for all protocols (http, tcp, udp) with the LBs
 // found in the Traefik store (redis). This allows kops running on multiple nodes to add their respective
 // IPs so that traefik can properly distribute the load.

--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -295,7 +295,7 @@ func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, defaultIp string, 
 			resolveInternalPorts, _ := getKopOverrideResolveInternalPort(dc, conf, "http", svcName, defaultResolveInternalPorts)
 
 			for i := range svc.LoadBalancer.Servers {
-				ip, changed := getKopOverrideBinding(dc, conf, "http", svcName, ip)
+				ip, changed := getKopOverrideBinding(dc, conf, "http", svcName, defaultIp)
 				if !changed {
 					// override with container IP if we have a routable IP
 					ip = getContainerNetworkIP(dc, conf, "http", svcName, ip)
@@ -352,7 +352,7 @@ func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, defaultIp string, 
 
 			for i := range svc.LoadBalancer.Servers {
 				// override with container IP if we have a routable IP
-				ip = getContainerNetworkIP(dc, conf, "tcp", svcName, ip)
+				defaultIp = getContainerNetworkIP(dc, conf, "tcp", svcName, defaultIp)
 
 				server := &svc.LoadBalancer.Servers[i]
 				server.Port = getContainerPort(dc, conf, "tcp", svcName, server.Port, resolveInternalPorts)
@@ -373,7 +373,7 @@ func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, defaultIp string, 
 
 			for i := range svc.LoadBalancer.Servers {
 				// override with container IP if we have a routable IP
-				ip = getContainerNetworkIP(dc, conf, "udp", svcName, ip)
+				defaultIp = getContainerNetworkIP(dc, conf, "udp", svcName, defaultIp)
 
 				server := &svc.LoadBalancer.Servers[i]
 				server.Port = getContainerPort(dc, conf, "udp", svcName, server.Port, resolveInternalPorts)

--- a/traefik_kop.go
+++ b/traefik_kop.go
@@ -70,7 +70,7 @@ func createConfigHandler(config Config, store TraefikStore, dp *docker.Provider,
 
 		if !dp.UseBindPortIP && !config.SkipReplace {
 			// if not using traefik's built in IP/Port detection, use our own
-			replaceIPs(dc, &conf, config.BindIP)
+			replaceIPs(dc, &conf, config.BindIP, config.ResolveInternalPorts)
 		} else {
 			log.Debug().Msgf("skipping IP replacement (useBindPortIP=%v, skipReplace=%v)", dp.UseBindPortIP, config.SkipReplace)
 		}
@@ -285,12 +285,15 @@ func filterServices(dc *dockerCache, conf *dynamic.Configuration, ns []string) {
 //
 // When using CNI, as indicated by the container label `traefik.docker.network`,
 // we will stick with the container IP.
-func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, ip string) {
+func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, defaultIp string, defaultResolveInternalPorts bool) {
 	// modify HTTP URLs
 	if conf.HTTP != nil && conf.HTTP.Services != nil {
 		for svcName, svc := range conf.HTTP.Services {
 			log := log.With().Str("service", svcName).Str("service-type", "http").Logger()
 			log.Debug().Msgf("found http service: %s", svcName)
+
+			resolveInternalPorts, _ := getKopOverrideResolveInternalPort(dc, conf, "http", svcName, defaultResolveInternalPorts)
+
 			for i := range svc.LoadBalancer.Servers {
 				ip, changed := getKopOverrideBinding(dc, conf, "http", svcName, ip)
 				if !changed {
@@ -309,7 +312,7 @@ func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, ip string) {
 					// labels ourselves.
 					log.Debug().Msgf("using load balancer URL for port detection: %s", server.URL)
 					u, _ := url.Parse(server.URL)
-					p := getContainerPort(dc, conf, "http", svcName, u.Port())
+					p := getContainerPort(dc, conf, "http", svcName, u.Port(), resolveInternalPorts)
 					if p != "" {
 						u.Host = ip + ":" + p
 					} else {
@@ -322,9 +325,9 @@ func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, ip string) {
 						scheme = server.Scheme
 					}
 					server.URL = fmt.Sprintf("%s://%s", scheme, ip)
-					port := getContainerPort(dc, conf, "http", svcName, server.Port)
+					port := getContainerPort(dc, conf, "http", svcName, server.Port, resolveInternalPorts)
 					if port != "" {
-						server.URL += ":" + server.Port
+						server.URL += ":" + port
 					}
 				}
 			}
@@ -344,14 +347,15 @@ func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, ip string) {
 		for svcName, svc := range conf.TCP.Services {
 			log := log.With().Str("service", svcName).Str("service-type", "tcp").Logger()
 			log.Debug().Msgf("found tcp service: %s", svcName)
+
+			resolveInternalPorts, _ := getKopOverrideResolveInternalPort(dc, conf, "tcp", svcName, defaultResolveInternalPorts)
+
 			for i := range svc.LoadBalancer.Servers {
 				// override with container IP if we have a routable IP
 				ip = getContainerNetworkIP(dc, conf, "tcp", svcName, ip)
 
 				server := &svc.LoadBalancer.Servers[i]
-				server.Port = getContainerPort(dc, conf, "tcp", svcName, server.Port)
-				log.Debug().Msgf("using ip '%s' and port '%s' for %s", ip, server.Port, svcName)
-				server.Address = ip
+				server.Port = getContainerPort(dc, conf, "tcp", svcName, server.Port, resolveInternalPorts)
 				if server.Port != "" {
 					server.Address += ":" + server.Port
 				}
@@ -364,14 +368,15 @@ func replaceIPs(dc *dockerCache, conf *dynamic.Configuration, ip string) {
 		for svcName, svc := range conf.UDP.Services {
 			log := log.With().Str("service", svcName).Str("service-type", "udp").Logger()
 			log.Debug().Msgf("found udp service: %s", svcName)
+
+			resolveInternalPorts, _ := getKopOverrideResolveInternalPort(dc, conf, "udp", svcName, defaultResolveInternalPorts)
+
 			for i := range svc.LoadBalancer.Servers {
 				// override with container IP if we have a routable IP
 				ip = getContainerNetworkIP(dc, conf, "udp", svcName, ip)
 
 				server := &svc.LoadBalancer.Servers[i]
-				server.Port = getContainerPort(dc, conf, "udp", svcName, server.Port)
-				log.Debug().Msgf("using ip '%s' and port '%s' for %s", ip, server.Port, svcName)
-				server.Address = ip
+				server.Port = getContainerPort(dc, conf, "udp", svcName, server.Port, resolveInternalPorts)
 				if server.Port != "" {
 					server.Address += ":" + server.Port
 				}

--- a/traefik_kop_test.go
+++ b/traefik_kop_test.go
@@ -47,7 +47,7 @@ func Test_replaceIPs(t *testing.T) {
 	fc := &dockerCache{client: &fakeDockerClient{}, list: nil, details: make(map[string]container.InspectResponse)}
 
 	// replace and test check again
-	replaceIPs(fc, cfg, "7.7.7.7")
+	replaceIPs(fc, cfg, "7.7.7.7", false)
 	require.NotContains(t, cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "172.20.0.2")
 
 	// full url
@@ -58,7 +58,7 @@ func Test_replaceIPs(t *testing.T) {
 	_, err = toml.DecodeFile("./fixtures/sample.toml", &cfg)
 	require.NoError(t, err)
 	require.Equal(t, "foobar", cfg.TCP.Services["TCPService0"].LoadBalancer.Servers[0].Address)
-	replaceIPs(fc, cfg, "7.7.7.7")
+	replaceIPs(fc, cfg, "7.7.7.7", false)
 	require.Equal(t, "7.7.7.7", cfg.TCP.Services["TCPService0"].LoadBalancer.Servers[0].Address)
 }
 
@@ -101,14 +101,14 @@ func Test_replacePorts(t *testing.T) {
 
 	// explicit label present
 	log.Debug().Msg("explicit label present")
-	replaceIPs(fc, cfg, "4.4.4.4")
+	replaceIPs(fc, cfg, "4.4.4.4", false)
 	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:8888"), "URL '%s' should end with '%s'", cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:8888")
 
 	// without label but no port binding
 	log.Debug().Msg("without label but no port binding")
 	delete(dc.container.Config.Labels, portLabel)
 	json.Unmarshal([]byte(NGINX_CONF_JSON), cfg)
-	replaceIPs(fc, cfg, "4.4.4.4")
+	replaceIPs(fc, cfg, "4.4.4.4", false)
 	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:80"))
 
 	// with port binding
@@ -122,7 +122,7 @@ func Test_replacePorts(t *testing.T) {
 	dc.container.HostConfig.PortBindings = portMap
 	logJSON("container", dc.container)
 	json.Unmarshal([]byte(NGINX_CONF_JSON), cfg)
-	replaceIPs(fc, cfg, "4.4.4.4")
+	replaceIPs(fc, cfg, "4.4.4.4", false)
 	require.False(t, strings.HasSuffix(cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:80"))
 	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:8888"))
 }
@@ -147,18 +147,209 @@ func Test_replacePortsNoService(t *testing.T) {
 	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx-nginx@docker"].LoadBalancer.Servers[0].URL, "172.20.0.2:80"))
 
 	// explicit label present
-	replaceIPs(fc, cfg, "4.4.4.4")
+	replaceIPs(fc, cfg, "4.4.4.4", false)
 	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx-nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:80"))
 
 	// without label but no port binding
 	json.Unmarshal([]byte(NGINX_CONF_JSON_DIFFRENT_SERVICE_NAME), cfg)
-	replaceIPs(fc, cfg, "4.4.4.4")
+	replaceIPs(fc, cfg, "4.4.4.4", false)
 	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx-nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:80"))
 
 	// with port binding
 	dc.container.HostConfig.PortBindings = portMap
 	json.Unmarshal([]byte(NGINX_CONF_JSON_DIFFRENT_SERVICE_NAME), cfg)
-	replaceIPs(fc, cfg, "4.4.4.4")
+	replaceIPs(fc, cfg, "4.4.4.4", false)
 	require.False(t, strings.HasSuffix(cfg.HTTP.Services["nginx-nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:80"))
 	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx-nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:8888"))
+}
+
+func Test_resolveInternalPortsHTTP(t *testing.T) {
+	portMap := nat.PortMap{
+		"80/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "8888"}},
+	}
+
+	dc := createTestClient(map[string]string{
+		"traefik.http.routers.nginx.entrypoints": "web-secure",
+	})
+	dc.container.HostConfig.PortBindings = portMap
+
+	dc.container.NetworkSettings = &container.NetworkSettings{}
+	dc.container.NetworkSettings.Ports = portMap
+
+	fc := &dockerCache{client: dc, list: nil, details: make(map[string]container.InspectResponse)}
+
+	cfg := &dynamic.Configuration{}
+	require.NoError(t, json.Unmarshal([]byte(NGINX_CONF_JSON), cfg))
+
+	// global flag false => resolve to host port 8888 because only one port exposed
+	replaceIPs(fc, cfg, "4.4.4.4", false)
+	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:8888"))
+
+	// global flag true => resolve to host port 8888
+	json.Unmarshal([]byte(NGINX_CONF_JSON), cfg)
+	replaceIPs(fc, cfg, "4.4.4.4", true)
+	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:8888"))
+}
+
+func Test_resolveInternalPortsLabelOverride(t *testing.T) {
+	portMap := nat.PortMap{
+		"80/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "8888"}},
+		"81/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "8181"}},
+	}
+
+	// global false, per-service label true
+	dc := createTestClient(map[string]string{
+		"traefik.http.routers.nginx.entrypoints":               "web-secure",
+		"traefik.http.services.nginx.loadbalancer.server.port": "80",
+		"kop.http.services.nginx.resolve-internal-ports":       "true",
+	})
+	dc.container.HostConfig.PortBindings = portMap
+
+	dc.container.NetworkSettings = &container.NetworkSettings{}
+	dc.container.NetworkSettings.Ports = portMap
+
+	fc := &dockerCache{client: dc, list: nil, details: make(map[string]container.InspectResponse)}
+	cfg := &dynamic.Configuration{}
+	require.NoError(t, json.Unmarshal([]byte(NGINX_CONF_JSON), cfg))
+
+	replaceIPs(fc, cfg, "4.4.4.4", false)
+	log.Debug().Msgf("cfg: %v", cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL)
+	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:8888"))
+
+	// global true, per-service label false
+	dc.container.Config.Labels = map[string]string{
+		"kop.http.services.nginx.resolve-internal-ports": "false",
+	}
+	json.Unmarshal([]byte(NGINX_CONF_JSON), cfg)
+	replaceIPs(fc, cfg, "4.4.4.4", true)
+	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:80"))
+}
+
+func Test_resolvePortLabel(t *testing.T) {
+	portMap := nat.PortMap{
+		"80/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "8888"}},
+		"90/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "9000"}},
+	}
+
+	dc := createTestClient(map[string]string{
+		"traefik.http.routers.nginx.entrypoints": "web-secure",
+		"kop.http.services.nginx.resolve-port":   "90",
+	})
+	dc.container.HostConfig.PortBindings = portMap
+
+	dc.container.NetworkSettings = &container.NetworkSettings{}
+	dc.container.NetworkSettings.Ports = portMap
+
+	fc := &dockerCache{client: dc, list: nil, details: make(map[string]container.InspectResponse)}
+	cfg := &dynamic.Configuration{}
+	require.NoError(t, json.Unmarshal([]byte(NGINX_CONF_JSON), cfg))
+
+	// resolve-port label should override and return host port 9000
+	replaceIPs(fc, cfg, "4.4.4.4", false)
+	require.True(t, strings.HasSuffix(cfg.HTTP.Services["nginx@docker"].LoadBalancer.Servers[0].URL, "4.4.4.4:9000"))
+}
+
+func Test_resolveInternalPortsTCP(t *testing.T) {
+	portMap := nat.PortMap{
+		"80/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "8888"}},
+		"10/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "10000"}},
+	}
+
+	dc := createTestClient(map[string]string{
+		"traefik.tcp.routers.nginx-tcp.entrypoints":               "web",
+		"traefik.tcp.services.nginx-tcp.loadbalancer.server.port": "80",
+	})
+	dc.container.HostConfig.PortBindings = portMap
+
+	fc := &dockerCache{client: dc, list: nil, details: make(map[string]container.InspectResponse)}
+
+	cfg := &dynamic.Configuration{}
+
+	err := json.Unmarshal([]byte(NGINX_CONF_JSON_TCP), cfg)
+	require.NoError(t, err)
+
+	replaceIPs(fc, cfg, "4.4.4.4", true)
+	require.Equal(t, "4.4.4.4:8888", cfg.TCP.Services["nginx-tcp@docker"].LoadBalancer.Servers[0].Address)
+}
+
+func Test_resolveInternalPortsUDP(t *testing.T) {
+	portMap := nat.PortMap{
+		"90/udp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "9000"}},
+		"10/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "10000"}},
+	}
+
+	dc := createTestClient(map[string]string{
+		"traefik.udp.routers.nginx-udp.entrypoints":               "udp",
+		"traefik.udp.services.nginx-udp.loadbalancer.server.port": "90",
+	})
+	dc.container.HostConfig.PortBindings = portMap
+
+	dc.container.NetworkSettings = &container.NetworkSettings{}
+	dc.container.NetworkSettings.Ports = portMap
+
+	fc := &dockerCache{client: dc, list: nil, details: make(map[string]container.InspectResponse)}
+
+	cfg := &dynamic.Configuration{}
+
+	err := json.Unmarshal([]byte(NGINX_CONF_JSON_UDP), cfg)
+	require.NoError(t, err)
+
+	replaceIPs(fc, cfg, "4.4.4.4", true)
+	require.Equal(t, "4.4.4.4:9000", cfg.UDP.Services["nginx-udp@docker"].LoadBalancer.Servers[0].Address)
+}
+
+func Test_resolveInternalPortsProtocolFiltering(t *testing.T) {
+	// TCP 22 -> 2222 and UDP 90 -> 9000 on the same container
+	portMap := nat.PortMap{
+		"22/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "2222"}},
+		"90/udp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "9000"}},
+	}
+
+	dc := createTestClient(map[string]string{
+		"traefik.tcp.routers.ssh.entrypoints": "ssh",
+		// "traefik.tcp.services.ssh.loadbalancer.server.port": "22",
+		"traefik.udp.routers.udp.entrypoints": "udp",
+		// "traefik.udp.services.udp.loadbalancer.server.port": "90",
+	})
+	dc.container.HostConfig.PortBindings = portMap
+
+	dc.container.NetworkSettings = &container.NetworkSettings{}
+	dc.container.NetworkSettings.Ports = portMap
+
+	fc := &dockerCache{client: dc, list: nil, details: make(map[string]container.InspectResponse)}
+
+	cfg := &dynamic.Configuration{
+		TCP: &dynamic.TCPConfiguration{
+			Routers: map[string]*dynamic.TCPRouter{
+				"ssh@docker": {Service: "ssh"},
+			},
+			Services: map[string]*dynamic.TCPService{
+				"ssh@docker": {
+					LoadBalancer: &dynamic.TCPServersLoadBalancer{
+						Servers: []dynamic.TCPServer{
+							{Address: "172.20.0.2:22"},
+						},
+					},
+				},
+			},
+		},
+		UDP: &dynamic.UDPConfiguration{
+			Routers: map[string]*dynamic.UDPRouter{
+				"udp@docker": {Service: "udp"},
+			},
+			Services: map[string]*dynamic.UDPService{
+				"udp@docker": {
+					LoadBalancer: &dynamic.UDPServersLoadBalancer{
+						Servers: []dynamic.UDPServer{
+							{Address: "172.20.0.2:90"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	replaceIPs(fc, cfg, "4.4.4.4", true)
+	require.Equal(t, "4.4.4.4:2222", cfg.TCP.Services["ssh@docker"].LoadBalancer.Servers[0].Address)
+	require.Equal(t, "4.4.4.4:9000", cfg.UDP.Services["udp@docker"].LoadBalancer.Servers[0].Address)
 }


### PR DESCRIPTION
## Problem 
When having multiple ports exposed `traefik-kop` can't auto resolve the label port to the host port.

## Fix
This PR allow the user to directly tell `traefik-kop` what internal port should get resolved to an host port 
using docker label `kop.<svcType>.services.<svcName>.resolve-port=<port>`

This looks first at `container.HostConfig.PortBindings` and after that at `container.NetworkSettings.Ports` 
For both it matches the protocol (so that an tcp port doesnt get an udp port) and the port:
```yml
ports:
  - 5000:50/tcp
labels:
  - kop.tcp.services.nginx.resolve-port=50
```

wil resolve internal port `50` to host port `5000` (Also works with random port `0`)

Also When the user does not want to use the special port assigment he can also use this:
```yml
labels:
 - kop.<svcType>.services.<svcName>.resolve-internal-ports = <true|false>
 - kop.resolve-internal-ports = <true|false>
```
or the new traefik-kop environemnt variable `RESOLVE_INTERNAL_PORTS=<true|false>` 
to allow direct auto resolving of the internal port to the host port.

These 3 options use the vanilla 
`traefik.<svcType>.services.<svcName>.loadbalancer.server.port=<port>` label
as the internal port then it resolves the port same as with  `resolve-port` (`HostConfig.PortBindings` then `NetworkSettings.Ports`)


These options also have precedence
1. `kop.<svcType>.services.<svcName>.resolve-port=<port>` label
2. `kop.<svcType>.services.<svcName>.resolve-internal-ports = <true|false>` label
3. `kop.resolve-internal-ports = <true|false>` label
4. `RESOLVE_INTERNAL_PORTS=<true|false>` env var

When using the 3 labels the `<svcName>` should be the declared traefik service name. When no service label use Traefik generates the service name. So to make it a little easier i have it made so that if the router name and service name mismatch (Mostly when traefik autogenerated the service name) it falls back to the router name.

## Tests
I added new tests for this new feature.

## Other Fixes
When splitting the tcp and udp address into host and port. I implemented the `net.SplitHostPort` method. Because if this is not used There could be complications with ipv6 addresses as they have `:` in the ip. Before the host and port where just split on `:`.